### PR TITLE
Clarify contract of TrajectoryView for looping.

### DIFF
--- a/hf1/arduino/controller.hh
+++ b/hf1/arduino/controller.hh
@@ -41,7 +41,11 @@ void TrajectoryController<TrajectoryViewType>::Update(const TimerSecondsType now
           StopTrajectory();
         } else {
           // The trajectory is set to loop. Stop and wait until it's time to restart.
-          if (*trajectory_.SecondsBetweenLoops() > 0) {
+          if (*trajectory_.SecondsBetweenLoops() == 0) {
+            // The trajectory should repeat immediately.
+            StartTrajectory();
+          } else {
+            // The trajectory should repeat after a while.
             Stop();
             state_ = kWaitingBeforeLooping;
             seconds_at_end_ = now_seconds;

--- a/hf1/arduino/trajectory.h
+++ b/hf1/arduino/trajectory.h
@@ -23,15 +23,19 @@ private:
 // view objects referencing them.
 template<typename TState> class TrajectoryView {
 public:
-  TrajectoryView() : num_waypoints_(0), waypoints_(NULL), loop_at_seconds_(-1) {}
+  TrajectoryView() : num_waypoints_(0), waypoints_(NULL), loop_after_seconds_(-1) {}
 
   // Does not take ownsership of the pointee, which must outlive this object.
-  TrajectoryView(int num_waypoints, const Waypoint<TState> *waypoints)
-    : num_waypoints_(num_waypoints), waypoints_(waypoints), loop_at_seconds_(-1) {}
+  TrajectoryView(int num_waypoints, const Waypoint<TState> *waypoints);
+
+  // Returns true if the trajectory is valid, e.g. no two waypoints defined for the same time.
+  static bool IsTrajectoryValid(int num_waypoints, const Waypoint<TState> *waypoints);
 
   int num_waypoints() const { return num_waypoints_; }
 
-  TrajectoryView &EnableLooping(TimerSecondsType after_seconds = 0);
+  // `after_seconds` must be enough time for the controller to take the state from the last
+  // waypoint to the first one.
+  TrajectoryView &EnableLooping(TimerSecondsType after_seconds);
   TrajectoryView &DisableLooping();
   bool IsLoopingEnabled() const;
   StatusOr<TimerSecondsType> SecondsBetweenLoops() const;
@@ -45,7 +49,7 @@ public:
 private:
   int num_waypoints_;
   const Waypoint<TState> *waypoints_;
-  TimerSecondsType loop_at_seconds_; // looping disabled if negative.
+  TimerSecondsType loop_after_seconds_; // looping disabled if negative.
 };
 
 #include "trajectory.hh"

--- a/hf1/common/status_or.h
+++ b/hf1/common/status_or.h
@@ -7,7 +7,8 @@ enum Status {
 
 template<typename ValueType> class StatusOr {
 public:
-  StatusOr(ValueType &&v) : status_(kSuccess), value_(v) {}
+  StatusOr(const ValueType &v) : status_(kSuccess), value_(v) {}  // Selected for lvalues.
+  StatusOr(ValueType &&v) : status_(kSuccess), value_(v) {} // Selected for rvalues.
   StatusOr(Status e) : status_(e) {}
   
   ValueType *operator->() { return &value_; }


### PR DESCRIPTION
Fixes #1. The bug claims that `EnableLooping(/*after_seconds=*/0)` does not repeat the trajectory. `after_seconds` is the time the robot can take to go from the last point to the first. Equating it to zero produces an impossible constraint. 

The robot was stopping because that value was resulting NaN and infinite velocity coordinates due to zero division, which made the yaw reference to be NaN, too. 

Actions taken:
* Trajectory derivatives break if the time between waypoints is zero.
* Trajectory construction breaks if two waypoints share the same time.
* `EnableLooping(0)` breaks because it's impossible to teleport any state in zero time.
