### PR TITLE
Make `common` tests build on macOS.

### DIFF
--- a/hf1/common/CMakeLists.txt
+++ b/hf1/common/CMakeLists.txt
@@ -1,5 +1,7 @@
 project(hf1_p2p_link_common)
 cmake_minimum_required(VERSION 2.8)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 add_subdirectory(test)
 add_library(hf1_p2p_link_common network.cpp p2p_packet_stream.cpp logger_interface.cpp utils.cpp)
 target_include_directories(hf1_p2p_link_common PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")

--- a/hf1/common/test/CMakeLists.txt
+++ b/hf1/common/test/CMakeLists.txt
@@ -7,7 +7,9 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # Setup testing
 enable_testing()
 find_package(GTest REQUIRED)
-include_directories(${GTEST_INCLUDE_DIR})
+if(DEFINED GTEST_INCLUDE_DIR)
+  include_directories(${GTEST_INCLUDE_DIR})
+endif()
 
 get_filename_component(PARENT_DIR ../ ABSOLUTE)
 include_directories(${PARENT_DIR})
@@ -18,7 +20,11 @@ add_executable(runUnitTests
 )
 
 # Link test executable against all dependency libraries.
-target_link_libraries(runUnitTests hf1_p2p_link_common pthread GTest::gtest_main)
+if(NOT DEFINED GTEST_INCLUDE_DIR)
+  target_link_libraries(runUnitTests hf1_p2p_link_common pthread GTest::gtest_main)
+else()
+  target_link_libraries(runUnitTests hf1_p2p_link_common libgtest.a libgtest_main.a pthread)
+endif()
 
 add_test(
     NAME runUnitTests

--- a/hf1/common/test/CMakeLists.txt
+++ b/hf1/common/test/CMakeLists.txt
@@ -1,13 +1,12 @@
 cmake_minimum_required(VERSION 2.8)
 project(hf1_p2p_link_common_tests)
 
-set(CMAKE_CXX_STANDARD 14)  # Required by GTest.
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Setup testing
 enable_testing()
 find_package(GTest REQUIRED)
-include_directories(${GTEST_INCLUDE_DIR})
 
 get_filename_component(PARENT_DIR ../ ABSOLUTE)
 include_directories(${PARENT_DIR})
@@ -18,7 +17,7 @@ add_executable(runUnitTests
 )
 
 # Link test executable against all dependency libraries.
-target_link_libraries(runUnitTests hf1_p2p_link_common libgtest.a libgtest_main.a pthread)
+target_link_libraries(runUnitTests hf1_p2p_link_common pthread GTest::gtest_main)
 
 add_test(
     NAME runUnitTests

--- a/hf1/common/test/CMakeLists.txt
+++ b/hf1/common/test/CMakeLists.txt
@@ -7,6 +7,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # Setup testing
 enable_testing()
 find_package(GTest REQUIRED)
+include_directories(${GTEST_INCLUDE_DIR})
 
 get_filename_component(PARENT_DIR ../ ABSOLUTE)
 include_directories(${PARENT_DIR})


### PR DESCRIPTION
Fixes #4. 

In addition to setting the C++ standard to avoid the error mentioned in #4, this change links GTest differently on macOS, as the previous way only works on Linux. This is done with conditional statements because the new way does not work on Linux.