### PR TITLE
TrajectoryViews support interpolated upsampling.

### DIFF
--- a/hf1/arduino/arduino.ino
+++ b/hf1/arduino/arduino.ino
@@ -87,14 +87,14 @@ void setup() {
   // base_state_controller.SetTargetState(Point(0.5, 0.5), M_PI / 4, 0.3, 0);  
   // base_speed_controller.SetTargetSpeeds(0.1, 10 * M_PI);
 
-  const int num_waypoints = 40;
-  const int points_per_segment = num_waypoints / 4;
-  for (int i = 0; i < points_per_segment; ++i) {
-    waypoints[i] = BaseWaypoint(i * 0.3, BaseTargetState({ BaseStateVars(Point(i * 0.1, 0), 0) }));
-    waypoints[i+points_per_segment] = BaseWaypoint((i+points_per_segment) * 0.3, BaseTargetState({ BaseStateVars(Point(1, -i * 0.1), 0) }));
-    waypoints[i+2*points_per_segment] = BaseWaypoint((i+2*points_per_segment) * 0.3, BaseTargetState({ BaseStateVars(Point(1 - i * 0.1, -1), 0) }));
-    waypoints[i+3*points_per_segment] = BaseWaypoint((i+3*points_per_segment) * 0.3, BaseTargetState({ BaseStateVars(Point(0, -1+0.1*i), 0) }));
-  }
+  // const int num_waypoints = 40;
+  // const int points_per_segment = num_waypoints / 4;
+  // for (int i = 0; i < points_per_segment; ++i) {
+  //   waypoints[i] = BaseWaypoint(i * 0.3, BaseTargetState({ BaseStateVars(Point(i * 0.1, 0), 0) }));
+  //   waypoints[i+points_per_segment] = BaseWaypoint((i+points_per_segment) * 0.3, BaseTargetState({ BaseStateVars(Point(1, -i * 0.1), 0) }));
+  //   waypoints[i+2*points_per_segment] = BaseWaypoint((i+2*points_per_segment) * 0.3, BaseTargetState({ BaseStateVars(Point(1 - i * 0.1, -1), 0) }));
+  //   waypoints[i+3*points_per_segment] = BaseWaypoint((i+3*points_per_segment) * 0.3, BaseTargetState({ BaseStateVars(Point(0, -1+0.1*i), 0) }));
+  // }
 
   // const int num_waypoints = sizeof(waypoints) / sizeof(waypoints[0]);
   // const float total_trajectory_seconds = 20.0;
@@ -106,7 +106,13 @@ void setup() {
   //   waypoints[i] = BaseWaypoint(t, BaseTargetState({ BaseStateVars(Point(x, y), 0) }));
   // }
 
-  base_trajectory_controller.trajectory(BaseTrajectoryView(num_waypoints, waypoints).EnableLooping(/*after_seconds=*/5.0));
+  const int num_waypoints = 4;
+  waypoints[0] = BaseWaypoint(0, BaseTargetState({ BaseStateVars(Point(0, 0), 0) }));
+  waypoints[1] = BaseWaypoint(3, BaseTargetState({ BaseStateVars(Point(1, 0), 0) }));
+  waypoints[2] = BaseWaypoint(6, BaseTargetState({ BaseStateVars(Point(1, -1), 0) }));
+  waypoints[3] = BaseWaypoint(9, BaseTargetState({ BaseStateVars(Point(0, -1), 0) }));
+  base_trajectory_controller.trajectory(BaseTrajectoryView(num_waypoints, waypoints).EnableLooping(/*after_seconds=*/3.0).EnableInterpolation({ .type = InterpolationType::kLinear, .num_sampling_points = 40 }));
+
   base_trajectory_controller.StartTrajectory();
 }
 

--- a/hf1/arduino/base_controller.cpp
+++ b/hf1/arduino/base_controller.cpp
@@ -113,6 +113,8 @@ BaseTrajectoryController::BaseTrajectoryController(BaseSpeedController *base_spe
   base_speed_controller_(*ASSERT_NOT_NULL(base_speed_controller)) {}
 
 void BaseTrajectoryController::Update(TimerSecondsType seconds_since_start, int current_waypoint_index) {
+  Serial.println("---");
+  Serial.printf("%f: %f, %f\n", trajectory().seconds(current_waypoint_index), trajectory().state(current_waypoint_index).location().position().x, trajectory().state(current_waypoint_index).location().position().y);
   // Get reference states.
   TimerSecondsType time_fraction = (seconds_since_start - trajectory().seconds(current_waypoint_index)) / (trajectory().seconds(current_waypoint_index + 1) - trajectory().seconds(current_waypoint_index));
   const State ref_position = trajectory().state(current_waypoint_index) + time_fraction * (trajectory().state(current_waypoint_index + 1) - trajectory().state(current_waypoint_index));

--- a/hf1/arduino/base_controller.cpp
+++ b/hf1/arduino/base_controller.cpp
@@ -113,15 +113,11 @@ BaseTrajectoryController::BaseTrajectoryController(BaseSpeedController *base_spe
   base_speed_controller_(*ASSERT_NOT_NULL(base_speed_controller)) {}
 
 void BaseTrajectoryController::Update(TimerSecondsType seconds_since_start, int current_waypoint_index) {
-  Serial.println("---");
-  Serial.printf("%f: %f, %f\n", trajectory().seconds(current_waypoint_index), trajectory().state(current_waypoint_index).location().position().x, trajectory().state(current_waypoint_index).location().position().y);
   // Get reference states.
   TimerSecondsType time_fraction = (seconds_since_start - trajectory().seconds(current_waypoint_index)) / (trajectory().seconds(current_waypoint_index + 1) - trajectory().seconds(current_waypoint_index));
-  const State ref_position = trajectory().state(current_waypoint_index) + time_fraction * (trajectory().state(current_waypoint_index + 1) - trajectory().state(current_waypoint_index));
-  const State first_derivative_at_index = trajectory().derivative(/*order=*/1, current_waypoint_index);
-  const State ref_velocity = first_derivative_at_index + time_fraction * (trajectory().derivative(/*order=*/1, current_waypoint_index + 1) - first_derivative_at_index);
-  const State second_derivative_at_index = trajectory().derivative(/*order=*/2, current_waypoint_index);
-  const State ref_acceleration = second_derivative_at_index + time_fraction * (trajectory().derivative(/*order=*/2, current_waypoint_index + 1) - second_derivative_at_index);
+  const State ref_position = trajectory().state(current_waypoint_index) * (1 - time_fraction) + trajectory().state(current_waypoint_index + 1) * time_fraction;
+  const State ref_velocity = trajectory().derivative(/*order=*/1, current_waypoint_index) * (1 - time_fraction) + trajectory().derivative(/*order=*/1, current_waypoint_index + 1) * time_fraction;
+  const State ref_acceleration = trajectory().derivative(/*order=*/2, current_waypoint_index) * (1 - time_fraction) + trajectory().derivative(/*order=*/2, current_waypoint_index + 1) * time_fraction;
   const float ref_yaw = atan2f(ref_velocity.location().position().y, ref_velocity.location().position().x);
 
   // Serial.printf("[ref] t:%f t+1:%f x:%f y:%f vx:%f vy:%f ax:%f ay:%f\n", trajectory().seconds(current_waypoint_index), trajectory().seconds(current_waypoint_index+1), ref_position.location().position().x, ref_position.location().position().y, ref_velocity.location().position().x, ref_velocity.location().position().y, ref_acceleration.location().position().x, ref_acceleration.location().position().y);

--- a/hf1/arduino/base_controller.h
+++ b/hf1/arduino/base_controller.h
@@ -79,22 +79,28 @@ using BaseWaypoint = Waypoint<BaseTargetState>;
 using BaseTrajectoryView = TrajectoryView<BaseTargetState>;
 
 // Controller commanding the base speed controller to move the robot's base over a sequence
-// of waypoints. It tries to reach each waypoint at the waypoint's time. 
+// of waypoints.
 // 
-// The base will not drive over a waypoint if it was not able to reach it on time. A far away 
-// waypoint with a time very near to the previous waypoint's time will not be reachable, 
-// either because the robot's maximum speed is insufficient, or because the time between 
-// waypoints is under the controller's sampling period (0.1 seconds).
+// The feedforward and feedback terms are taken from:
+// R. L. S. Sousa, M. D. do Nascimento Forte, F. G. Nogueira, B. C. Torrico, 
+// “Trajectory tracking control of a nonholonomic mobile robot with differential drive”, 
+// in Proc. IEEE Biennial Congress of Argentina (ARGENCON), pp. 1–6, 2016.
+//
+// The position, velocity and acceleration references are linearly interpolated from the
+// current and next target waypoints by looking ahead in the trajectory. This reduces the
+// tracking error due to the base's maximum dynamics (see base class' documentation for more
+// information).
+//
+// The base will not drive over a waypoint if it was not able to reach it on time. A far 
+// waypoint's state with a time very near to the previous waypoint's time will not be 
+// reachable, either because the robot's maximum acceleration and speed are insufficient, 
+// or because the time between waypoints is under the controller's sampling period (0.1 
+// seconds).
 //
 // Also, any obstacle and driving hurdle or error can result in not reaching a waypoint in 
 // time. When the waypoint's time constraint cannot be met and the waypoint is the last one 
 // in the trajectory, the robot will stop. But if the waypoint is not the last one, the 
 // robot will skip to the next one.
-// 
-// This controller is based on:
-// R. L. S. Sousa, M. D. do Nascimento Forte, F. G. Nogueira, B. C. Torrico, 
-// “Trajectory tracking control of a nonholonomic mobile robot with differential drive”, 
-// in Proc. IEEE Biennial Congress of Argentina (ARGENCON), pp. 1–6, 2016.
 class BaseTrajectoryController : public TrajectoryController<BaseTrajectoryView> {
 public:
   BaseTrajectoryController(BaseSpeedController *base_speed_controller);

--- a/hf1/arduino/base_state.h
+++ b/hf1/arduino/base_state.h
@@ -20,6 +20,10 @@ public:
     return BaseStateVars(position_ * factor, yaw_ * factor);
   }
 
+  float DistanceFrom(const BaseStateVars &state) const {
+    return (position() - state.position()).norm();
+  }
+
 private:
   Point position_;
   float yaw_;

--- a/hf1/arduino/controller.h
+++ b/hf1/arduino/controller.h
@@ -41,9 +41,7 @@ private:
   bool is_started_;
   TimerSecondsType start_seconds_;
   int current_waypoint_index_;
-
   ControllerState state_;
-  TimerSecondsType seconds_at_end_;
 };
 
 #include "controller.hh"

--- a/hf1/arduino/controller.hh
+++ b/hf1/arduino/controller.hh
@@ -1,8 +1,8 @@
 template<typename TrajectoryViewType>
 TrajectoryController<TrajectoryViewType>::TrajectoryController(const float run_period_seconds)
   : Controller(run_period_seconds),
-    state_(kStopped),
-    current_waypoint_index_(0) {}
+    current_waypoint_index_(0),
+    state_(kStopped) {}
 
 template<typename TrajectoryViewType>
 void TrajectoryController<TrajectoryViewType>::trajectory(const TrajectoryViewType &trajectory) {
@@ -35,7 +35,7 @@ void TrajectoryController<TrajectoryViewType>::Update(const TimerSecondsType now
       if (!maybe_index.ok()) { break; }
       current_waypoint_index_ = *maybe_index;
       Update(seconds_since_start, current_waypoint_index_);
-      if (current_waypoint_index_ >= trajectory_.num_waypoints() - 1) {
+      if (current_waypoint_index_ >= trajectory_.NumWaypoints() - 1) {
         if (!trajectory_.IsLoopingEnabled()) {
           // The trajectory is not set to loop.
           StopTrajectory();

--- a/hf1/arduino/controller.hh
+++ b/hf1/arduino/controller.hh
@@ -1,19 +1,21 @@
+#include "trajectory.h"
+
 template<typename TrajectoryViewType>
 TrajectoryController<TrajectoryViewType>::TrajectoryController(const float run_period_seconds)
   : Controller(run_period_seconds),
-    current_waypoint_index_(0),
+    target_waypoint_index_(0),
     state_(kStopped) {}
 
 template<typename TrajectoryViewType>
 void TrajectoryController<TrajectoryViewType>::trajectory(const TrajectoryViewType &trajectory) {
   trajectory_ = trajectory;
-  current_waypoint_index_ = 0;
+  target_waypoint_index_ = 0;
   state_ = kStopped;
 }
 
 template<typename TrajectoryViewType>
 void TrajectoryController<TrajectoryViewType>::StartTrajectory() {
-  current_waypoint_index_ = 0;
+  target_waypoint_index_ = 0;
   start_seconds_ = GetTimerSeconds();
   state_ = kFollowingTrajectory;
 }
@@ -31,16 +33,17 @@ void TrajectoryController<TrajectoryViewType>::Update(const TimerSecondsType now
       break;
     case kFollowingTrajectory: {
       const TimerSecondsType seconds_since_start = now_seconds - start_seconds_;
-      const auto maybe_index = trajectory_.FindWaypointIndexBeforeSeconds(seconds_since_start, current_waypoint_index_);
+      const auto maybe_index = trajectory_.FindWaypointIndexBeforeSeconds(seconds_since_start, target_waypoint_index_);
       if (!maybe_index.ok()) { break; }
-      current_waypoint_index_ = *maybe_index;
-      Update(seconds_since_start, current_waypoint_index_);
-      if (current_waypoint_index_ >= trajectory_.NumWaypoints() - 1) {
-        if (!trajectory_.IsLoopingEnabled()) {
-          // The trajectory is not set to loop.
-          StopTrajectory();
-        }
+      target_waypoint_index_ = *maybe_index;
+
+      Update(seconds_since_start, target_waypoint_index_);
+
+      if (!trajectory_.IsLoopingEnabled() && 
+          target_waypoint_index_ >= trajectory_.NumWaypoints() - 1) {
+        StopTrajectory();
       }
+
       break;
     }
   }

--- a/hf1/arduino/head_state.h
+++ b/hf1/arduino/head_state.h
@@ -3,6 +3,7 @@
 
 #include "state.h"
 #include "point.h"
+#include <math.h>
 
 class HeadStateVars {
 public:
@@ -18,6 +19,12 @@ public:
 
   HeadStateVars operator*(float factor) const {
     return HeadStateVars(pitch_ * factor, roll_ * factor);
+  }
+
+  float DistanceFrom(const HeadStateVars &state) const {
+    const float pitch_diff = pitch() - state.pitch();
+    const float pitch_roll = roll() - state.roll();
+    return sqrtf(pitch_diff * pitch_diff + pitch_roll * pitch_roll);
   }
 
 private:

--- a/hf1/arduino/point.cpp
+++ b/hf1/arduino/point.cpp
@@ -28,3 +28,7 @@ float Point::norm() const {
 Point operator*(float k, const Point &p) { 
   return Point(k * p.x, k * p.y); 
 }
+
+float Point::DistanceFrom(const Point &p) const {
+  return ((*this) - p).norm();
+}

--- a/hf1/arduino/point.h
+++ b/hf1/arduino/point.h
@@ -13,6 +13,7 @@ class Point {
     Point operator/(float d) const;
     Point operator*(float d) const;
     float norm() const;
+    float DistanceFrom(const Point &p) const;
 };
 
 Point operator*(float k, const Point &p);

--- a/hf1/arduino/state.h
+++ b/hf1/arduino/state.h
@@ -40,6 +40,10 @@ public:
     return result;
   }
 
+  virtual float DistanceFrom(const State<TStateVars, Order> &state) const {
+    return location().DistanceFrom(state.location());
+  }
+
   int order() const { return Order; }
 
   const TStateVars &location() const { return states_[0]; }

--- a/hf1/arduino/trajectory.h
+++ b/hf1/arduino/trajectory.h
@@ -3,7 +3,7 @@
 
 #include "status_or.h"
 
-// Defines a state of the robot at a given time. 
+// Defines a state at a given time.
 template<typename TState>
 class Waypoint {
 public:
@@ -81,6 +81,7 @@ public:
 
   TrajectoryView &EnableInterpolation(const InterpolationConfig &config);
   TrajectoryView &DisableInterpolation();
+  const InterpolationConfig &interpolation_config() const { return interpolation_config_; }
 
   StatusOr<int> FindWaypointIndexBeforeSeconds(TimerSecondsType seconds, int prev_result_index = 0) const;
 

--- a/hf1/arduino/trajectory.h
+++ b/hf1/arduino/trajectory.h
@@ -4,7 +4,8 @@
 #include "status_or.h"
 
 // Defines a state of the robot at a given time. 
-template<typename TState> class Waypoint {
+template<typename TState>
+class Waypoint {
 public:
   Waypoint() : seconds_(0) {}
   Waypoint(TimerSecondsType seconds, const TState &state) 
@@ -13,15 +14,39 @@ public:
   TimerSecondsType seconds() const { return seconds_; }
   const TState &state() const { return state_; }
 
+  Waypoint operator+(const Waypoint &other) const {
+    return Waypoint(seconds_ + other.seconds_, state_ + other.state_);
+  }
+
+  Waypoint operator-(const Waypoint &other) const {
+    return Waypoint(seconds_ - other.seconds_, state_ - other.state_);
+  }
+
+  Waypoint operator*(float factor) const {
+    return Waypoint(seconds_ * factor, state_ * factor);
+  }
+
+  Waypoint operator/(float divisor) const {
+    return Waypoint(seconds_ / divisor, state_ / divisor);
+  }
+
 private:
   TimerSecondsType seconds_;
   TState state_;
 };
 
+// Cubic interpolation uses centripetal Catmull-Rom splines.
+typedef enum { kNone, kLinear, kCubic } InterpolationType;
+typedef struct {
+  InterpolationType type;
+  int num_sampling_points;
+} InterpolationConfig;
+
 // A view to a collection of waypoints.
 // The view does not own the memory containing the waypoints, so they must outlive any 
 // view objects referencing them.
-template<typename TState> class TrajectoryView {
+template<typename TState>
+class TrajectoryView {
 public:
   TrajectoryView() : num_waypoints_(0), waypoints_(NULL), loop_after_seconds_(-1) {}
 
@@ -31,7 +56,21 @@ public:
   // Returns true if the trajectory is valid, e.g. no two waypoints defined for the same time.
   static bool IsTrajectoryValid(int num_waypoints, const Waypoint<TState> *waypoints);
 
-  int num_waypoints() const { return num_waypoints_; }
+  // Returns the number of waypoints in the trajectory, after applying interpolation.
+  // If interpolation is enabled, this won't match the number of waypoints passed to the
+  // constructor. The valid range is then [0, num_sampling_points).
+  int NumWaypoints() const;
+
+  // Returns the waypoint at the given index, after applying interpolation.
+  // If interpolation is enabled, the valid index range is [0, num_sampling_points).
+  // Otherwise, it is [0, num_waypoints];
+  Waypoint<TState> GetWaypoint(int index) const;
+
+  // Returns the duration of one trajectory lap. 
+  // If no looping is enabled, this is the time between the first and last waypoints.
+  // If looping is enabled, this is the time above plus the time it takes to return to the 
+  // starting waypoint.
+  float LapDuration() const;
 
   // `after_seconds` must be enough time for the controller to take the state from the last
   // waypoint to the first one.
@@ -40,16 +79,24 @@ public:
   bool IsLoopingEnabled() const;
   StatusOr<TimerSecondsType> SecondsBetweenLoops() const;
 
+  TrajectoryView &EnableInterpolation(const InterpolationConfig &config);
+  TrajectoryView &DisableInterpolation();
+
   StatusOr<int> FindWaypointIndexBeforeSeconds(TimerSecondsType seconds, int prev_result_index = 0) const;
 
-  const TState &state(int index) const;
+  TState state(int index) const;
   TState derivative(int order, int index) const;
   float seconds(int index) const;
 
 private:
+  // Returns the waypoint without interpolation for the given index, assuming a periodic
+  // trajectory.
+  Waypoint<TState> GetPeriodicWaypoint(int index) const;
+
   int num_waypoints_;
   const Waypoint<TState> *waypoints_;
-  TimerSecondsType loop_after_seconds_; // looping disabled if negative.
+  InterpolationConfig interpolation_config_;
+  TimerSecondsType loop_after_seconds_; // looping disabled if negative.  
 };
 
 #include "trajectory.hh"

--- a/hf1/arduino/trajectory.hh
+++ b/hf1/arduino/trajectory.hh
@@ -1,20 +1,123 @@
 #include <math.h>
 
+namespace {
+
 static int compare_seconds(const void *a, const void *b) {
   return ceilf(*reinterpret_cast<const TimerSecondsType *>(a) - *reinterpret_cast<const TimerSecondsType *>(b));
 }
 
 template<typename TState>
+static Waypoint<TState> Bezier(const Waypoint<TState> &a, const Waypoint<TState> &b, const Waypoint<TState> &c, const Waypoint<TState> &d, const float t) {
+  const auto a1 = a * (1 - t) + b * t;
+  const auto a2 = b * (1 - t) + c * t;
+  const auto a3 = c * (1 - t) + d * t;
+  const auto b1 = a1 * (1 - t) + a2 * t;
+  const auto b2 = a2 * (1 - t) + a3 * t;
+  return b1 * (1 - t) + b2 * t;
+}
+
+template<typename TState>
+static Waypoint<TState> CentripetalCatmullRom(const Waypoint<TState> &p0, const Waypoint<TState> &p1, const Waypoint<TState> &p2, const Waypoint<TState> &p3, const float t) {
+  const auto d1 = p0.state().DistanceFrom(p1.state());
+  const auto d2 = p1.state().DistanceFrom(p2.state());
+  const auto d3 = p2.state().DistanceFrom(p3.state());
+  const auto b0 = p1;
+  const auto b1 = p1 + (p2 * d1 - p0 * d2 + p1 * (d2 - d1)) / (3 * d1 + 3 * std::sqrt(d1 * d2));
+  const auto b2 = p2 + (p1 * d3 - p3 * d2 + p2 * (d2 - d3)) / (3 * d3 + 3 * std::sqrt(d2 * d3));
+  const auto b3 = p2;
+  return Bezier(b0, b1, b2, b3, t);
+}
+
+} // namespace
+
+template<typename TState>
 TrajectoryView<TState>::TrajectoryView(int num_waypoints, const Waypoint<TState> *waypoints)
-  : num_waypoints_(num_waypoints), waypoints_(waypoints), loop_after_seconds_(-1) {
+  : num_waypoints_(num_waypoints),
+    waypoints_(waypoints),
+    interpolation_config_(InterpolationConfig{ .type = kNone, .num_sampling_points = 0 }),
+    loop_after_seconds_(-1) {
   if (num_waypoints > 0) {
     ASSERTM(IsTrajectoryValid(num_waypoints, waypoints), "Two waypoints defined for the same time.");
   }
 }
 
 template<typename TState>
+int TrajectoryView<TState>::NumWaypoints() const {
+  if (interpolation_config_.type == kNone) {
+    return num_waypoints_;
+  } else {
+    return interpolation_config_.num_sampling_points;
+  }
+}
+
+template<typename TState>
+Waypoint<TState> TrajectoryView<TState>::GetPeriodicWaypoint(int index) const {
+  float lap_duration = LapDuration();
+  // If looping is not enabled, in order to enable derivative computation, assume that time
+  // will be the average time between waypoints.
+  if (loop_after_seconds_ < 0) {
+    const TimerSecondsType waypoints_duration = waypoints_[num_waypoints_ - 1].seconds() - waypoints_[0].seconds();
+    lap_duration += waypoints_duration / num_waypoints_;
+  }
+  const int num_completed_laps = index / num_waypoints_;
+  const auto normalized_index = IndexMod(index, num_waypoints_);
+  const auto waypoint_time = waypoints_[normalized_index].seconds() + lap_duration * num_completed_laps;  
+  const auto &waypoint_state = waypoints_[normalized_index].state();
+  return Waypoint<TState>(waypoint_time, waypoint_state);  
+}
+
+template<typename TState>
+Waypoint<TState> TrajectoryView<TState>::GetWaypoint(int index) const {
+  switch (interpolation_config_.type) {
+    case kNone:
+      return waypoints_[index];
+    case kLinear:
+      {
+        const int num_lap_waypoints = IsLoopingEnabled() ? num_waypoints_ : num_waypoints_ - 1;
+        const float remapped_index = (index * num_lap_waypoints) / static_cast<float>(interpolation_config_.num_sampling_points);
+        const int i1 = floorf(remapped_index);
+        const int i2 = i1 + 1;
+        const float t = remapped_index - i1;
+        return GetPeriodicWaypoint(i1) * (1 - t) + GetPeriodicWaypoint(i2) * t;
+      }
+    case kCubic:
+      {
+        const int num_lap_waypoints = IsLoopingEnabled() ? num_waypoints_ : num_waypoints_ - 1;
+        const float remapped_index = (index * num_lap_waypoints) / static_cast<float>(interpolation_config_.num_sampling_points);
+        const int i1 = static_cast<int>(floorf(remapped_index));
+        ASSERT(i1 >= 0 && i1 < num_waypoints_);
+        const Waypoint<TState> &w1 = waypoints_[i1];
+
+        if (IsLoopingEnabled()) {
+          // TODO: w0 should be in the w1<-w2 direction on the first lap
+          const Waypoint<TState> &w0 = waypoints_[IndexMod(i1 - 1, num_waypoints_)];
+          const Waypoint<TState> &w2 = waypoints_[IndexMod(i1 + 1, num_waypoints_)];
+          const Waypoint<TState> &w3 = waypoints_[IndexMod(i1 + 2, num_waypoints_)];
+          const float t = remapped_index - i1;
+          return CentripetalCatmullRom(w0, w1, w2, w3, t);
+        } else {
+          // TODO: complete this.
+          return waypoints_[index];
+        }
+      }
+  }
+}
+
+template<typename TState>
+TrajectoryView<TState> &TrajectoryView<TState>::EnableInterpolation(const InterpolationConfig &config) {
+  interpolation_config_ = config;
+  return *this;
+}
+
+template<typename TState>
+TrajectoryView<TState> &TrajectoryView<TState>::DisableInterpolation() {
+  interpolation_config_.type = kNone;
+  return *this;
+}
+
+template<typename TState>
 bool TrajectoryView<TState>::IsTrajectoryValid(int num_waypoints, const Waypoint<TState> *waypoints) {
-    // Check if there are more than one waypoint for the same time.
+  // Check if there are more than one waypoint for the same time.
   TimerSecondsType sorted_waypoint_seconds[num_waypoints];
   for (int i = 0; i < num_waypoints; ++i) { sorted_waypoint_seconds[i] = waypoints[i].seconds(); }
   qsort(sorted_waypoint_seconds, num_waypoints, sizeof(sorted_waypoint_seconds[0]), &compare_seconds);
@@ -29,7 +132,7 @@ bool TrajectoryView<TState>::IsTrajectoryValid(int num_waypoints, const Waypoint
 template<typename TState>
 TrajectoryView<TState> &TrajectoryView<TState>::EnableLooping(TimerSecondsType after_seconds) {
   ASSERTM(after_seconds > 0, "The state cannot go back from the last to the first waypoint in no time.");
-  if (num_waypoints_ == 0) { 
+  if (num_waypoints_ == 0) {
     loop_after_seconds_ = -1;
   } else {
     loop_after_seconds_ = after_seconds;
@@ -38,13 +141,13 @@ TrajectoryView<TState> &TrajectoryView<TState>::EnableLooping(TimerSecondsType a
 }
 
 template<typename TState>
-TrajectoryView<TState> &TrajectoryView<TState>::DisableLooping() { 
+TrajectoryView<TState> &TrajectoryView<TState>::DisableLooping() {
   loop_after_seconds_ = -1;
   return *this;
 }
 
 template<typename TState>
-bool TrajectoryView<TState>::IsLoopingEnabled() const { 
+bool TrajectoryView<TState>::IsLoopingEnabled() const {
   return loop_after_seconds_ >= 0;
 }
 
@@ -60,25 +163,28 @@ template<typename TState>
 StatusOr<int> TrajectoryView<TState>::FindWaypointIndexBeforeSeconds(TimerSecondsType seconds, int prev_result_index) const {
   if (num_waypoints_ == 0 || seconds < this->seconds(0)) { return Status::kUnavailableError; }
   int i = prev_result_index;
-  while((IsLoopingEnabled() || i < num_waypoints_) && this->seconds(i) < seconds) { ++i; }
+  while ((IsLoopingEnabled() || i < NumWaypoints()) && this->seconds(i) < seconds) { ++i; }
   return i - 1;
 }
 
 template<typename TState>
-float TrajectoryView<TState>::seconds(int index) const {
-  const TimerSecondsType trajectory_duration = waypoints_[num_waypoints_ - 1].seconds() - waypoints_[0].seconds();
-  // If looping is enabled the time to get back to the initial state was given.
-  // If looping is not enabled, in order to enable derivative computation, assume that time
-  // will be the average time between waypoints.
-  const TimerSecondsType loop_after_seconds = loop_after_seconds_ >= 0 ? loop_after_seconds_ : trajectory_duration / num_waypoints_;
-  const int normalized_index = IndexMod(index, num_waypoints_);
-  const TimerSecondsType prev_loops_seconds = (trajectory_duration + loop_after_seconds) * (index / num_waypoints_);
-  return waypoints_[normalized_index].seconds() + prev_loops_seconds;
+float TrajectoryView<TState>::LapDuration() const {
+  TimerSecondsType duration = waypoints_[num_waypoints_ - 1].seconds() - waypoints_[0].seconds();
+  // If looping is enabled, the time to get back to the initial state is part of a lap.
+  if (loop_after_seconds_ >= 0) {
+    duration += loop_after_seconds_;
+  }
+  return duration;
 }
 
 template<typename TState>
-const TState &TrajectoryView<TState>::state(int index) const {
-  return waypoints_[IndexMod(index, num_waypoints_)].state();
+float TrajectoryView<TState>::seconds(int index) const {
+  return GetWaypoint(index).seconds();
+}
+
+template<typename TState>
+TState TrajectoryView<TState>::state(int index) const {
+  return GetWaypoint(index).state();
 }
 
 template<typename TState>


### PR DESCRIPTION
Trajectories can be upsampled with linear or cubic interpolation by TrajectoryView. The interpolated view is generated on the fly, which does not increase memory complexity (it stays as O(N) and not as O(k*N), being k the upsampling factor with k > 1).

Cubic interpolation is achieved with centripetal Catmull-Rom curves, which avoid the cusps and self-intersections happening in their uniform parameterization, and stay closer to the trajectory polygon than the chordal parameterization ([more info](http://www.cemyuksel.com/research/catmullrom_param)).

All 6 combinations for trajectory interpolation and looping have been tested successfully on the robot: 
* Looping: disabled, enabled.
* Interpolation: none, linear, cubic.