### PR TITLE
Enable finer control with better wheel speed estimation and higher frequency loops.

### DIFF
--- a/hf1/arduino/arduino.ino
+++ b/hf1/arduino/arduino.ino
@@ -96,22 +96,23 @@ void setup() {
   //   waypoints[i+3*points_per_segment] = BaseWaypoint((i+3*points_per_segment) * 0.3, BaseTargetState({ BaseStateVars(Point(0, -1+0.1*i), 0) }));
   // }
 
-  // const int num_waypoints = sizeof(waypoints) / sizeof(waypoints[0]);
-  // const float total_trajectory_seconds = 20.0;
-  // for (int i = 0; i < num_waypoints; ++i) {
-  //   const float t = i * total_trajectory_seconds / num_waypoints;
-  //   const float w = 2 * M_PI / total_trajectory_seconds;
-  //   const float x = sin(w * t);
-  //   const float y = -1 + cos(w * t);
-  //   waypoints[i] = BaseWaypoint(t, BaseTargetState({ BaseStateVars(Point(x, y), 0) }));
-  // }
+  const int num_waypoints = sizeof(waypoints) / sizeof(waypoints[0]);
+  const float total_trajectory_seconds = 20.0;
+  for (int i = 0; i < num_waypoints; ++i) {
+    const float t = i * total_trajectory_seconds / num_waypoints;
+    const float w = 2 * M_PI / total_trajectory_seconds;
+    const float x = sin(w * t);
+    const float y = -1 + cos(w * t);
+    waypoints[i] = BaseWaypoint(t, BaseTargetState({ BaseStateVars(Point(x, y), 0) }));
+  }
+  base_trajectory_controller.trajectory(BaseTrajectoryView(num_waypoints, waypoints).EnableLooping(/*after_seconds=*/total_trajectory_seconds / num_waypoints).EnableInterpolation({ .type = InterpolationType::kLinear, .num_sampling_points = 40 }));
 
-  const int num_waypoints = 4;
-  waypoints[0] = BaseWaypoint(0, BaseTargetState({ BaseStateVars(Point(0, 0), 0) }));
-  waypoints[1] = BaseWaypoint(3, BaseTargetState({ BaseStateVars(Point(1, 0), 0) }));
-  waypoints[2] = BaseWaypoint(6, BaseTargetState({ BaseStateVars(Point(1, -1), 0) }));
-  waypoints[3] = BaseWaypoint(9, BaseTargetState({ BaseStateVars(Point(0, -1), 0) }));
-  base_trajectory_controller.trajectory(BaseTrajectoryView(num_waypoints, waypoints).EnableLooping(/*after_seconds=*/3.0).EnableInterpolation({ .type = InterpolationType::kLinear, .num_sampling_points = 40 }));
+  // const int num_waypoints = 4;
+  // waypoints[0] = BaseWaypoint(0, BaseTargetState({ BaseStateVars(Point(0, 0), 0) }));
+  // waypoints[1] = BaseWaypoint(3, BaseTargetState({ BaseStateVars(Point(1, 0), 0) }));
+  // waypoints[2] = BaseWaypoint(6, BaseTargetState({ BaseStateVars(Point(1, -1), 0) }));
+  // waypoints[3] = BaseWaypoint(9, BaseTargetState({ BaseStateVars(Point(0, -1), 0) }));
+  // base_trajectory_controller.trajectory(BaseTrajectoryView(num_waypoints, waypoints).EnableLooping(/*after_seconds=*/3.0).EnableInterpolation({ .type = InterpolationType::kLinear, .num_sampling_points = 40 }));
 
   base_trajectory_controller.StartTrajectory();
 }

--- a/hf1/arduino/base_controller.cpp
+++ b/hf1/arduino/base_controller.cpp
@@ -7,17 +7,17 @@
 #include "robot_state_estimator.h"
 
 #define kBaseStateControllerLoopPeriod 0.33  // [s]
-#define kBaseTrajectoryControllerLoopPeriod 0.1 // [s]
+#define kBaseTrajectoryControllerLoopPeriod 0.02 // [s]
 
 #define kKx 3.0   // [1/s]
 #define kKy 64.0 // [1/m^2]
 #define kKyaw 32.0    // [1/m]
 
 #define kBaseTrajectoryControllerK1 0.8
-#define kBaseTrajectoryControllerK2 3.0*3
+#define kBaseTrajectoryControllerK2 3.0
 #define kBaseTrajectoryControllerK3 0.8
 
-#define kBaseTrajectoryTangentialSpeedMax 0.4
+#define kBaseTrajectoryTangentialSpeedMax 0.5
 #define kBaseTrajectoryAngularSpeedMax (2*M_PI/3)
 
 #define kMaxPositionErrorForAtState 0.15 // [m]

--- a/hf1/arduino/motors.cpp
+++ b/hf1/arduino/motors.cpp
@@ -1,7 +1,7 @@
 #include "motors.h"
 #include "Arduino.h"
 
-#define kPWMFrequencyHz 50
+#define kPWMFrequencyHz 1000
 #define kPWMPeriodTicks ((16000000 / 32) / kPWMFrequencyHz)
 
 void InitMotors() {

--- a/hf1/arduino/motors.cpp
+++ b/hf1/arduino/motors.cpp
@@ -1,7 +1,7 @@
 #include "motors.h"
 #include "Arduino.h"
 
-#define kPWMFrequencyHz 1000
+#define kPWMFrequencyHz 2000
 #define kPWMPeriodTicks ((16000000 / 32) / kPWMFrequencyHz)
 
 void InitMotors() {

--- a/hf1/arduino/wheel_controller.h
+++ b/hf1/arduino/wheel_controller.h
@@ -5,19 +5,14 @@
 #include "pid.h"
 #include "controller.h"
 #include "robot_model.h"
-
-void InitWheelSpeedControl();
-
-int32_t GetLeftWheelTickCount();
-int32_t GetRightWheelTickCount();
+#include "wheel_state_estimator.h"
 
 typedef void (DutyCycleSetter)(float duty_cycle);
-typedef int32_t (WheelTickCountGetter)(void);
 
 class WheelSpeedController : public Controller {
 public:
   // No ownership of the pointee is taken by this object.
-  WheelSpeedController(WheelTickCountGetter * const wheel_tick_count_getter, DutyCycleSetter * const duty_cycle_setter);
+  WheelSpeedController(const WheelStateFilter * const wheel_state_filter_, DutyCycleSetter * const duty_cycle_setter);
 
   // Returns the maximum attainable linear speed [m/s].
   float GetMaxLinearSpeed() const;
@@ -47,13 +42,11 @@ protected:
 private:
   float DutyCycleFromLinearSpeed(float meters_per_second) const;
 
-  WheelTickCountGetter &wheel_tick_count_getter_;
+  const WheelStateFilter &wheel_state_filter_;
   DutyCycleSetter &duty_cycle_setter_;
 
   float last_run_seconds_;
   float time_start_;
-  int32_t num_wheel_ticks_start_;
-  float average_wheel_speed_;
   bool is_turning_forward_;
   float target_speed_;
   float initial_target_speed_;

--- a/hf1/arduino/wheel_state_estimator.cpp
+++ b/hf1/arduino/wheel_state_estimator.cpp
@@ -1,0 +1,65 @@
+#include "wheel_state_estimator.h"
+#include "encoders.h"
+#include "timer.h"
+#include "utils.h"
+#include "robot_model.h"
+#include "logger_interface.h"
+
+// Approximate rate at which the state estimation is updated.
+#define kUpdatePeriodSeconds (1/160.0)
+
+// Target fraction of the last measured wheel speed fed to the filter after kWheelSpeedDecaySeconds.
+#define kWheelSpeedDecayReduction 1e-3
+// Seconds required to reduce the wheel speed to kOdomCenterVelocityDecayReduction of the last measurement.
+#define kWheelSpeedDecaySeconds 0.2
+#define kWheelSpeedDecayFactor (exp((log(kWheelSpeedDecayReduction) * kUpdatePeriodSeconds) / kWheelSpeedDecaySeconds))
+
+static WheelStateEstimator *wheel_state_estimator_singleton = nullptr;
+
+void WheelStateEstimator::LeftEncoderIsr(TimerTicksType timer_ticks) {  
+  ASSERT(wheel_state_estimator_singleton != nullptr);
+  wheel_state_estimator_singleton->left_wheel_state_filter_.NotifyEncoderEdge(timer_ticks);
+}
+
+void WheelStateEstimator::RightEncoderIsr(TimerTicksType timer_ticks) {
+  ASSERT(wheel_state_estimator_singleton != nullptr);
+  wheel_state_estimator_singleton->right_wheel_state_filter_.NotifyEncoderEdge(timer_ticks);
+}
+
+WheelStateEstimator::WheelStateEstimator() 
+  : PeriodicRunnable(static_cast<TimerSecondsType>(kUpdatePeriodSeconds)) {
+  ASSERT(wheel_state_estimator_singleton == nullptr);
+  wheel_state_estimator_singleton = this;
+}
+
+void WheelStateEstimator::Init() {
+  AddEncoderIsrs(&WheelStateEstimator::LeftEncoderIsr, &WheelStateEstimator::RightEncoderIsr);  
+}
+
+void WheelStateEstimator::RunAfterPeriod(TimerNanosType now_nanos, TimerNanosType nanos_since_last_call) {
+  left_wheel_state_filter_.UpdateState();
+  right_wheel_state_filter_.UpdateState();  
+}
+
+void WheelStateFilter::NotifyEncoderEdge(TimerTicksType timer_ticks) {
+  if (last_encoder_edge_timer_ticks_.ok()) {
+    const auto timer_ticks_between_encoder_edges = timer_ticks - *last_encoder_edge_timer_ticks_;
+    wheel_state_.speed((kWheelRadius * kRadiansPerWheelTick) / SecondsFromTimerTicks(timer_ticks_between_encoder_edges));
+  }
+  last_encoder_edge_timer_ticks_ = timer_ticks;
+}
+
+void WheelStateFilter::UpdateState() {
+  NO_ENCODER_IRQ {
+    // When no encoder edges arrive, assume the wheel slows down to prevent estimating 
+    // constant speed when it's actually stopped.
+    wheel_state_.speed(wheel_state_.speed() * kWheelSpeedDecayFactor);  
+  }
+}
+
+WheelState WheelStateFilter::state() const {
+  NO_ENCODER_IRQ {
+    return wheel_state_;
+  }
+  return WheelState();  // Avoid compiler warning.
+}

--- a/hf1/arduino/wheel_state_estimator.h
+++ b/hf1/arduino/wheel_state_estimator.h
@@ -1,0 +1,57 @@
+#ifndef WHEEL_STATE_ESTIMATOR_INCLUDED_
+#define WHEEL_STATE_ESTIMATOR_INCLUDED_
+
+#include "timer.h"
+#include "status_or.h"
+#include "periodic_runnable.h"
+
+class WheelState {
+  friend class WheelStateFilter;
+public:
+  WheelState() : speed_(0) {}
+  WheelState(float speed) : speed_(speed) {}
+  float speed() const { return speed_; }
+
+protected:
+  void speed(float speed) { speed_ = speed; };
+private:
+  float speed_;
+};
+
+class WheelStateFilter {
+  friend class WheelStateEstimator;
+public:
+  WheelStateFilter() 
+    : last_encoder_edge_timer_ticks_(Status::kDoesNotExistError) {}
+
+  WheelState state() const;
+
+protected:
+  void UpdateState();
+  void NotifyEncoderEdge(TimerTicksType timer_ticks);
+
+private:
+  StatusOr<TimerTicksType> last_encoder_edge_timer_ticks_;
+  WheelState wheel_state_;
+};
+
+class WheelStateEstimator : public PeriodicRunnable {
+public:
+  WheelStateEstimator();
+
+  static void Init();
+
+  const WheelStateFilter &left_wheel_state_filter() const { return left_wheel_state_filter_; }
+  const WheelStateFilter &right_wheel_state_filter() const { return right_wheel_state_filter_; }
+
+protected:
+  static void LeftEncoderIsr(TimerTicksType timer_ticks);
+  static void RightEncoderIsr(TimerTicksType timer_ticks);
+  void RunAfterPeriod(TimerNanosType now_nanos, TimerNanosType nanos_since_last_call) override;
+
+private:
+  WheelStateFilter left_wheel_state_filter_;
+  WheelStateFilter right_wheel_state_filter_;
+};
+
+#endif  // WHEEL_STATE_ESTIMATOR_INCLUDED_


### PR DESCRIPTION
The new wheel estimator is more accurate in the short term than previous one. This allows for higher frequency wheel control loops because they are no longer limited by the speed estimation latency. The base controller can now run at a higher frequency, too, which enables finer control with a higher PWM frequency (2 kHz).