### PR TITLE
Read IMU asynchronously.

### DIFF
--- a/hf1/arduino/base_imu.cpp
+++ b/hf1/arduino/base_imu.cpp
@@ -61,7 +61,6 @@ BaseIMU::CalibrationData BaseIMU::GetCalibrationData() {
 void BaseIMU::StopCalibration() {
   bno055_.setMode(BNO055_OPERATION_MODE_IMUPLUS);
 }
-#include <Arduino.h>
 
 bool BaseIMU::LoadCalibrationData() {
   uint8_t calibration_data_size = 0;

--- a/hf1/arduino/base_imu.h
+++ b/hf1/arduino/base_imu.h
@@ -3,9 +3,9 @@
 #include "vector.h"
 #include "status_or.h"
 
-class BodyIMU {
+class BaseIMU {
 public:
-  BodyIMU();
+  BaseIMU();
 
   void Init();
   void Run();
@@ -64,4 +64,4 @@ private:
   Vector<3> CanonicalizeEulerVector(const Vector<3> &vector);
 };
 
-extern BodyIMU body_imu;
+extern BaseIMU base_imu;

--- a/hf1/arduino/base_state_filter.cpp
+++ b/hf1/arduino/base_state_filter.cpp
@@ -105,7 +105,7 @@ BaseStateFilter::BaseStateFilter()
   const float rpx = kStdevOdomPosX * kStdevOdomPosX;  // [m^2]
   const float rpy = kStdevOdomPosY * kStdevOdomPosY;  // [m^2]
   const float rpa = kStdevOdomYaw * kStdevOdomYaw;  // [rad^2]
-  // Velocity is calculated from position, 
+  // Velocity is calculated from position.
   const float rvx = (2 * rpx * rpx) / time_inc_2;  // [(m/s)^2]
   const float rvy = (2 * rpy * rpy) / time_inc_2;  // [(m/s)^2]
   // Since yaw is represented as a complex number, we need the noise variance in each component.

--- a/hf1/arduino/base_state_filter.cpp
+++ b/hf1/arduino/base_state_filter.cpp
@@ -1,8 +1,6 @@
 #include <BasicLinearAlgebra.h>
 #include "base_state_filter.h"
 
-// Approximate rate at which the state estimation is updated.
-#define kApproximateUpdateRate 160.0
 
 // Standard deviations of the IMU measures.
 #define kStdevIMUAccelX 0.0118  // [m/s^2] Estimated from accelerometer data in https://forums.adafruit.com/viewtopic.php?t=122078
@@ -10,14 +8,15 @@
 #define kStdevIMUYaw 0.001   // [rad] Estimated experimentally. The measure comes from the IMU internal filter, so noise is pretty low.
 
 // Standard deviations of the odometry measures.
-#define kStdevOdomPosX (0.005 / (0.85 * kApproximateUpdateRate))  // +/-5 mm error in a 0.85-seconds test (21.5 cm/s) at the approximate sample rate [m]
-#define kStdevOdomPosY (0.005 / (0.85 * kApproximateUpdateRate))  // +/-5 mm error in a 0.85-seconds test (21.5 cm/s) at the approximate sample rate [m]
+#define kOdomSamplingRate 160.0
+#define kStdevOdomPosX (0.005 / (0.85 * kOdomSamplingRate))  // +/-5 mm error in a 0.85-seconds test (21.5 cm/s) at the approximate sample rate [m]
+#define kStdevOdomPosY (0.005 / (0.85 * kOdomSamplingRate))  // +/-5 mm error in a 0.85-seconds test (21.5 cm/s) at the approximate sample rate [m]
 // For a 90-degree turn in 1 second, we get +/-10 degrees of error. However, testing different
 // trajectories, we see the error can be much higher for sudden movements, so we apply an error
 // multiplier to account for the worst case, as it can have devastating effects on the
 // localization accuracy in the long term. In this way, yaw is mostly determined by the IMU
 // measurement whose accuracy is stable across our acceleration range.
-#define kStdevOdomYaw (100 * (M_PI / 180 * (10 / (90.0 / 90.0 * kApproximateUpdateRate))))  // +/-10 degreed after 90 degrees turn, at 90 deg/s and the approximate sample rate [rad]
+#define kStdevOdomYaw (100 * (M_PI / 180 * (10 / (90.0 / 90.0 * kOdomSamplingRate))))  // +/-10 degreed after 90 degrees turn, at 90 deg/s and the approximate sample rate [rad]
 
 // Any estimate above this value is rejected.
 // Meant to prevent too high estimates due to co-occuring encoder edges.
@@ -33,7 +32,8 @@
 #define kOdomCenterVelocityDecayReduction 1e-3
 // Seconds required to reduce the odometry center velocity to kOdomCenterVelocityDecayReduction of the last measurement.
 #define kOdomCenterVelocityDecaySeconds ((kWheelRadius * kRadiansPerWheelTick) / 0.5)  // The time between wheel ticks at 0.5 m/s.
-#define kOdomCenterVelocityDecayFactor (exp(log(kOdomCenterVelocityDecayReduction) / (kApproximateUpdateRate * kOdomCenterVelocityDecaySeconds)))
+// Time constant of the decay factor applied to the last odometry center measure: exp(-time_since_last_odom_center_measure / kOdomCenterDecayTimeConstant)
+#define kOdomCenterDecayTimeConstant (-kOdomCenterVelocityDecaySeconds / log(kOdomCenterVelocityDecayReduction))
 
 BaseStateFilter::BaseStateFilter() 
   : last_odom_timer_ticks_(0), 
@@ -128,15 +128,13 @@ void BaseStateFilter::EstimateState(TimerTicksType timer_ticks) {
   const float state_update_timer_inc = SecondsFromTimerTicks(timer_ticks - last_state_update_timer_ticks_);
   kalman_.F(0, 2) = state_update_timer_inc;
   kalman_.F(1, 3) = state_update_timer_inc;
-
-  // Decay odometry velocity, so it goes to zero if no more wheel ticks are received.
-  odom_center_velocity_.x *= kOdomCenterVelocityDecayFactor;
-  odom_center_velocity_.y *= kOdomCenterVelocityDecayFactor;
   
   // Update state estimation.
   // Avoid yaw discontinuities messing with the Kalman estimate by representing the yaw as a
   // complex number on the unit circle.
-  kalman_.update(/*obs=*/{ odom_center_.x, odom_center_.y, odom_center_velocity_.x, odom_center_velocity_.y, cosf(odom_yaw_), sinf(odom_yaw_) }, 
+  // Decay odometry velocity, so it goes to zero if no more wheel ticks are received.  
+  const float odom_velocity_decay_factor = expf(-SecondsFromTimerTicks(timer_ticks - last_odom_timer_ticks_) / kOdomCenterDecayTimeConstant);
+  kalman_.update(/*obs=*/{ odom_center_.x, odom_center_.y, odom_center_velocity_.x * odom_velocity_decay_factor, odom_center_velocity_.y * odom_velocity_decay_factor, cosf(odom_yaw_), sinf(odom_yaw_) }, 
                  /*command=*/{ imu_acceleration_.x, imu_acceleration_.y, cosf(imu_yaw_), sinf(imu_yaw_) });
 
   // Serial.printf("F = {{ %f %f %f %f %f }, {%f %f %f %f %f}, {%f %f %f %f %f}, { %f %f %f %f %f }, {%f %f %f %f %f}}\n", kalman_.F(0, 0), kalman_.F(0, 1), kalman_.F(0, 2), kalman_.F(0, 3), kalman_.F(0, 4), kalman_.F(1, 0), kalman_.F(1, 1), kalman_.F(1, 2), kalman_.F(1, 3), kalman_.F(1, 4), kalman_.F(2, 0), kalman_.F(2, 1), kalman_.F(2, 2), kalman_.F(2, 3), kalman_.F(2, 4), kalman_.F(3, 0), kalman_.F(3, 1), kalman_.F(3, 2), kalman_.F(3, 3), kalman_.F(3, 4), kalman_.F(4, 0), kalman_.F(4, 1), kalman_.F(4, 2), kalman_.F(4, 3), kalman_.F(4, 4));

--- a/hf1/arduino/base_state_filter.h
+++ b/hf1/arduino/base_state_filter.h
@@ -35,6 +35,8 @@ class BaseStateFilter {
       return NanosFromTimerTicks(last_state_update_timer_ticks_);
     }
 
+    TimerTicksType last_state_update_timer_ticks() const { return last_state_update_timer_ticks_; }
+
   private:
     float GetFilteredYaw() const;
     

--- a/hf1/arduino/bno055.cpp
+++ b/hf1/arduino/bno055.cpp
@@ -4,7 +4,6 @@
 #include "timer.h"
 #include "logger_interface.h"
 
-#define DEVICE_ADDRESS    static_cast<uint8_t>(0x28)
 #define EXPECTED_CHIP_ID  0xa0
 
 #define CHIP_ID_REG             0
@@ -25,8 +24,8 @@ constexpr TimerNanosType kI2CBusFrequency = 100'000;
 constexpr TimerNanosType kReadTimeoutPerByteNs = (20 * 1'000'000'000ULL) / kI2CBusFrequency;
 constexpr TimerNanosType kReadTimeoutConstantNs = 100'000'000;
 
-static void ReadFromI2C(uint8_t register_address, void *data, uint8_t length) {
-	Wire.beginTransmission(DEVICE_ADDRESS);	
+static void ReadFromI2C(uint8_t device_address, uint8_t register_address, void *data, uint8_t length) {
+	Wire.beginTransmission(device_address);	
 	Wire.write(register_address);
 	const auto tx_result = Wire.endTransmission();
   switch(tx_result) {
@@ -37,7 +36,7 @@ static void ReadFromI2C(uint8_t register_address, void *data, uint8_t length) {
     default: ASSERTM(false, "ReadFromI2C ERROR: unknown error.");
   }
   SleepForNanos(150000);
-	Wire.requestFrom(DEVICE_ADDRESS, length);
+	Wire.requestFrom(device_address, length);
   auto bytes = reinterpret_cast<uint8_t *>(data);
   const auto start_ns = GetTimerNanoseconds();
   const TimerNanosType timeout_ns = length * kReadTimeoutPerByteNs + kReadTimeoutConstantNs;
@@ -48,8 +47,8 @@ static void ReadFromI2C(uint8_t register_address, void *data, uint8_t length) {
   ASSERTM(length == 0, "ReadFromI2C ERROR: device responded by the timeout expired reading data.");
 }
 
-static void WriteToI2C(uint8_t register_address, const void *data, uint8_t length) {
-	Wire.beginTransmission(DEVICE_ADDRESS);
+static void WriteToI2C(uint8_t device_address, uint8_t register_address, const void *data, uint8_t length) {
+	Wire.beginTransmission(device_address);
 	Wire.write(register_address);	
   auto bytes = reinterpret_cast<const uint8_t *>(data);
 	for(uint8_t i = 0; i < length; ++i) {
@@ -60,14 +59,14 @@ static void WriteToI2C(uint8_t register_address, const void *data, uint8_t lengt
 	SleepForNanos(150000);
 }
 
-static uint8_t ReadByteFromI2C(uint8_t reg_addr) {
+static uint8_t ReadByteFromI2C(uint8_t device_address, uint8_t reg_addr) {
   uint8_t data;
-  ReadFromI2C(reg_addr, &data, 1);
+  ReadFromI2C(device_address, reg_addr, &data, 1);
   return data;
 }
 
-static void WriteByteToI2C(uint8_t reg_addr, uint8_t value) {
-  WriteToI2C(reg_addr, &value, 1);
+static void WriteByteToI2C(uint8_t device_address, uint8_t reg_addr, uint8_t value) {
+  WriteToI2C(device_address, reg_addr, &value, 1);
 }
 
 static uint8_t SetBytePart(uint8_t dest, uint8_t offset, uint8_t mask, uint8_t value) {
@@ -78,36 +77,45 @@ static uint8_t GetBytePart(uint8_t source, uint8_t offset, uint8_t mask) {
   return (source & mask) >> offset;
 }
 
-static void WritePageID(uint8_t page_id) {
-  WriteByteToI2C(PAGE_ID_REG, page_id); 
+static void WritePageID(uint8_t device_address, uint8_t page_id) {
+  WriteByteToI2C(device_address, PAGE_ID_REG, page_id); 
 }
 
-static BNO055OperationMode GetOperationMode() {
-  WritePageID(0);
-  return static_cast<BNO055OperationMode>(GetBytePart(ReadByteFromI2C(OPERATION_MODE_REG), OPERATION_MODE_POS, OPERATION_MODE_MASK));
+static BNO055OperationMode GetOperationMode(uint8_t device_address) {
+  WritePageID(device_address, 0);
+  return static_cast<BNO055OperationMode>(GetBytePart(ReadByteFromI2C(device_address, OPERATION_MODE_REG), OPERATION_MODE_POS, OPERATION_MODE_MASK));
 }
 
-static void SetOperationMode(BNO055OperationMode op_mode) {
-  if (GetOperationMode() == BNO055_OPERATION_MODE_CONFIG) {
-    WriteByteToI2C(
+static void SetOperationMode(uint8_t device_address, BNO055OperationMode op_mode) {
+  if (GetOperationMode(device_address) == BNO055_OPERATION_MODE_CONFIG) {
+    WriteByteToI2C(device_address, 
       OPERATION_MODE_REG, 
-      SetBytePart(ReadByteFromI2C(OPERATION_MODE_REG), OPERATION_MODE_POS, OPERATION_MODE_MASK, op_mode)
+      SetBytePart(ReadByteFromI2C(device_address, OPERATION_MODE_REG), OPERATION_MODE_POS, OPERATION_MODE_MASK, op_mode)
     );
   } else {
-    WriteByteToI2C(
+    WriteByteToI2C(device_address, 
       OPERATION_MODE_REG, 
-      SetBytePart(ReadByteFromI2C(OPERATION_MODE_REG), OPERATION_MODE_POS, OPERATION_MODE_MASK, BNO055_OPERATION_MODE_CONFIG) 
+      SetBytePart(ReadByteFromI2C(device_address, OPERATION_MODE_REG), OPERATION_MODE_POS, OPERATION_MODE_MASK, BNO055_OPERATION_MODE_CONFIG) 
     );
     if (op_mode != BNO055_OPERATION_MODE_CONFIG) {
-      WriteByteToI2C(
+      WriteByteToI2C(device_address,
         OPERATION_MODE_REG, 
-        SetBytePart(ReadByteFromI2C(OPERATION_MODE_REG), OPERATION_MODE_POS, OPERATION_MODE_MASK, op_mode)
+        SetBytePart(ReadByteFromI2C(device_address, OPERATION_MODE_REG), OPERATION_MODE_POS, OPERATION_MODE_MASK, op_mode)
       );
     }
   }
 }
 
+BNO055::BNO055(uint8_t device_address) : device_address_(device_address), state_(State::kIdle) {
+  for (size_t i = 0; i < sizeof(last_vectors_) / sizeof(last_vectors_[0]); ++i) {
+    // Mark this type of vector as "not yet requested".
+    last_vectors_[i] = Status::kDoesNotExistError;
+  }
+}
+
 bool BNO055::begin(BNO055OperationMode op_mode) {
+  WaitForPendingTransferToFinish();
+
   // Hard reset.
   pinMode(27, OUTPUT);
   digitalWrite(27, 0);
@@ -116,12 +124,13 @@ bool BNO055::begin(BNO055OperationMode op_mode) {
   SleepForNanos(650'000'000);  // Typical POR time is 650 ms.
 
   Wire.begin();
+  Wire.setDefaultTimeout(100'000/* us */);
   SleepForNanos(1'000'000);
   
   // Wait for the chip to start up and check that we have the right model.
   SleepForNanos(400'000'000); // Typical start-up time is 400 ms.
   int timeout_ms = 200;  
-  while(ReadByteFromI2C(CHIP_ID_REG) != EXPECTED_CHIP_ID && timeout_ms > 0) {
+  while(ReadByteFromI2C(device_address_, CHIP_ID_REG) != EXPECTED_CHIP_ID && timeout_ms > 0) {
     SleepForNanos(10'000'000);
     timeout_ms -= 10;
   }
@@ -129,13 +138,13 @@ bool BNO055::begin(BNO055OperationMode op_mode) {
 
   // Reset the chip in case begin() has been called a second time, 
   // or the MCU was reset by the programmer without power-cycling the IMU.
-  SetOperationMode(BNO055_OPERATION_MODE_CONFIG);
-  WriteByteToI2C(SYS_TRIGGER_REG, 0x20);
+  SetOperationMode(device_address_, BNO055_OPERATION_MODE_CONFIG);
+  WriteByteToI2C(device_address_, SYS_TRIGGER_REG, 0x20);
 
   // Check that we have the right chip. Retry until it is on.
   SleepForNanos(650'000'000);  // Typical POR time is 650 ms.
   timeout_ms = 200;
-  while(ReadByteFromI2C(CHIP_ID_REG) != EXPECTED_CHIP_ID && timeout_ms > 0) {
+  while(ReadByteFromI2C(device_address_, CHIP_ID_REG) != EXPECTED_CHIP_ID && timeout_ms > 0) {
     SleepForNanos(10'000'000);
     timeout_ms -= 10;
   }
@@ -143,18 +152,18 @@ bool BNO055::begin(BNO055OperationMode op_mode) {
   SleepForNanos(50'000'000);
 
   // Configure external crystal.
-  SetOperationMode(BNO055_OPERATION_MODE_CONFIG);
+  SetOperationMode(device_address_, BNO055_OPERATION_MODE_CONFIG);
   SleepForNanos(25'000'000);
-  WritePageID(0);
-  WriteByteToI2C(SYS_TRIGGER_REG, 0x80);
+  WritePageID(device_address_, 0);
+  WriteByteToI2C(device_address_, SYS_TRIGGER_REG, 0x80);
   SleepForNanos(600'000'000);
   timeout_ms = 1000;
-  while((ReadByteFromI2C(SYS_CLK_STATUS_REG) & 1) && timeout_ms > 0) {
+  while((ReadByteFromI2C(device_address_, SYS_CLK_STATUS_REG) & 1) && timeout_ms > 0) {
     SleepForNanos(10'000'000);
     timeout_ms -= 10;
   }
-  ASSERTM(!(ReadByteFromI2C(SYS_CLK_STATUS_REG) & 1), "Timed out waiting for ST_MAIN_CLK to become low.");
-  ASSERTM(ReadByteFromI2C(SYS_TRIGGER_REG) & 0x80, "Unable to start external oscillator.");
+  ASSERTM(!(ReadByteFromI2C(device_address_, SYS_CLK_STATUS_REG) & 1), "Timed out waiting for ST_MAIN_CLK to become low.");
+  ASSERTM(ReadByteFromI2C(device_address_, SYS_TRIGGER_REG) & 0x80, "Unable to start external oscillator.");
 
   setMode(op_mode);
   SleepForNanos(20'000'000);
@@ -163,14 +172,33 @@ bool BNO055::begin(BNO055OperationMode op_mode) {
 }
 
 void BNO055::setMode(BNO055OperationMode op_mode) {
-  SetOperationMode(op_mode);
+  WaitForPendingTransferToFinish();
+  SetOperationMode(device_address_, op_mode);
   last_mode_ = op_mode;
 }
 
-Vector<3> BNO055::getVector(TVectorType vector_type) const {
+void BNO055::WaitForPendingTransferToFinish() {
+  const StatusOr<TVectorType> in_progress_type = GetVectorTypeOfTransferInProgress();
+  if (!in_progress_type.ok()) { return; }
+  while(GetLastRequestedVector(*in_progress_type).status() == Status::kInProgressError) {
+    Run();  
+  }
+}
+
+Vector<3> BNO055::getVector(TVectorType vector_type) {
+  // If there is a pending asynchronous transfer, wait for it to finish.
+  const StatusOr<TVectorType> in_progress_type = GetVectorTypeOfTransferInProgress();
+  if (in_progress_type.ok()) {
+    WaitForPendingTransferToFinish();
+    // Return the vector if it matches the requested type and was received correctly.
+    if (*in_progress_type == vector_type && GetLastRequestedVector(*in_progress_type).ok()) {
+      return *GetLastRequestedVector(*in_progress_type);
+    }
+  }
+
   // Assume that page 0 is selected.
   uint8_t buffer[6];
-  ReadFromI2C(static_cast<uint8_t>(vector_type), buffer, sizeof(buffer) / sizeof(buffer[0]));
+  ReadFromI2C(device_address_, static_cast<uint8_t>(vector_type), buffer, sizeof(buffer) / sizeof(buffer[0]));
   const int16_t x = ((int16_t)buffer[0]) | (((int16_t)buffer[1]) << 8);
   const int16_t y = ((int16_t)buffer[2]) | (((int16_t)buffer[3]) << 8);
   const int16_t z = ((int16_t)buffer[4]) | (((int16_t)buffer[5]) << 8);
@@ -186,10 +214,11 @@ Vector<3> BNO055::getVector(TVectorType vector_type) const {
   return Vector<3>();
 }
 
-BNO055::CalibrationStatus BNO055::GetCalibrationStatus() const {
-  const uint8_t reg = ReadByteFromI2C(CALIBRATION_STATUS_REG);  
+BNO055::CalibrationStatus BNO055::GetCalibrationStatus() {
+  WaitForPendingTransferToFinish();
+  const uint8_t reg = ReadByteFromI2C(device_address_, CALIBRATION_STATUS_REG);  
   return {
-    .operation_mode = GetOperationMode(),
+    .operation_mode = GetOperationMode(device_address_),
     .system = static_cast<uint8_t>((reg >> 6) & 0b11),
     .gyroscopes = static_cast<uint8_t>((reg >> 4) & 0b11),
     .accelerometers = static_cast<uint8_t>((reg >> 2) & 0b11),
@@ -197,11 +226,12 @@ BNO055::CalibrationStatus BNO055::GetCalibrationStatus() const {
   };
 }
 
-BNO055::CalibrationData BNO055::GetCalibrationData() const {
-  SetOperationMode(BNO055_OPERATION_MODE_CONFIG);
+BNO055::CalibrationData BNO055::GetCalibrationData() {
+  WaitForPendingTransferToFinish();
+  SetOperationMode(device_address_, BNO055_OPERATION_MODE_CONFIG);
   CalibrationData calibration_data;
-  ReadFromI2C(SENSOR_OFFSETS_BASE_ADDRESS, &calibration_data, SENSOR_OFFSETS_NUM_REGISTERS);
-  SetOperationMode(last_mode_);
+  ReadFromI2C(device_address_, SENSOR_OFFSETS_BASE_ADDRESS, &calibration_data, SENSOR_OFFSETS_NUM_REGISTERS);
+  SetOperationMode(device_address_, last_mode_);
   return calibration_data;
 }
 
@@ -227,9 +257,108 @@ bool BNO055::CalibrationStatus::IsFullyCalibrated() const {
   }  
 }
 
-void BNO055::SetCalibrationData(const CalibrationData &data) const {
-  SetOperationMode(BNO055_OPERATION_MODE_CONFIG);
+void BNO055::SetCalibrationData(const CalibrationData &data) {
+  WaitForPendingTransferToFinish();
+  SetOperationMode(device_address_, BNO055_OPERATION_MODE_CONFIG);
   SleepForNanos(25000000);
-  WriteToI2C(SENSOR_OFFSETS_BASE_ADDRESS, &data, SENSOR_OFFSETS_NUM_REGISTERS);
-  SetOperationMode(last_mode_);
+  WriteToI2C(device_address_, SENSOR_OFFSETS_BASE_ADDRESS, &data, SENSOR_OFFSETS_NUM_REGISTERS);
+  SetOperationMode(device_address_, last_mode_);
+}
+
+int BNO055::GetLastVectorIndexFromVectorType(TVectorType type) const {
+  switch(type) {
+    case VECTOR_EULER: return 0;
+    case VECTOR_LINEAR_ACCEL: return 1;
+    case VECTOR_RAW_ACCEL: return 2;
+    default: { ASSERT(false); return 0; }
+  }
+}
+
+TVectorType BNO055::GetVectorTypeFromLastVectorIndex(int index) const {
+  const static TVectorType vector_type_from_index[] = { VECTOR_EULER, VECTOR_LINEAR_ACCEL, VECTOR_RAW_ACCEL };
+  ASSERT(index >= 0);
+  ASSERT(index < static_cast<int>(sizeof(vector_type_from_index) / sizeof(vector_type_from_index[0])));
+  return vector_type_from_index[index];
+}
+
+StatusOr<TVectorType> BNO055::GetVectorTypeOfTransferInProgress() const {
+  for (size_t i = 0; i < sizeof(last_vectors_) / sizeof(last_vectors_[0]); ++i) {
+    const auto &last_vector = last_vectors_[i];
+    if (last_vector.status() == Status::kInProgressError) {
+      return GetVectorTypeFromLastVectorIndex(i);
+    } 
+  }
+  return Status::kDoesNotExistError;
+}
+
+Status BNO055::RequestVectorAsync(TVectorType vector_type) {
+  // Fail if there is any request in progress.
+  if (GetVectorTypeOfTransferInProgress().ok()) {
+    return Status::kExistsError;
+  }
+
+  // Mark the vector type as being requested.
+  last_vectors_[GetLastVectorIndexFromVectorType(vector_type)] = Status::kInProgressError;
+
+  // Initiate tx request to send register address.
+	Wire.beginTransmission(device_address_);	
+	ASSERT(Wire.write(static_cast<uint8_t>(vector_type)) == 1);
+  Wire.sendTransmission();
+  
+  state_ = State::kWaitingForRegisterAddressWritten;
+  return Status::kSuccess;
+}
+
+StatusOr<Vector<3>> BNO055::GetLastRequestedVector(TVectorType vector_type) const {
+  return last_vectors_[GetLastVectorIndexFromVectorType(vector_type)];
+}
+
+void BNO055::Run() {
+  switch(state_) {
+    case State::kIdle: break;
+
+    case State::kWaitingForRegisterAddressWritten:
+      if (!Wire.done()) { break; }
+      if (Wire.getError() != 0) {
+        const auto in_progress_type = GetVectorTypeOfTransferInProgress();
+        ASSERT(in_progress_type.ok());
+        last_vectors_[GetLastVectorIndexFromVectorType(*in_progress_type)] = Status::kUnavailableError;
+        state_ = kIdle;
+        break;
+      }
+
+      Wire.sendRequest(device_address_, sizeof(Vector<3>));
+      state_ = State::kReadingData;
+      break;
+
+    case State::kReadingData:
+      if (Wire.done()) { break; }
+      state_ = State::kIdle;
+      const auto in_progress_type = GetVectorTypeOfTransferInProgress();
+      ASSERT(in_progress_type.ok());
+      auto &last_vector = last_vectors_[GetLastVectorIndexFromVectorType(*in_progress_type)];
+      if (Wire.getError() != 0) {
+        last_vector = Status::kUnavailableError;
+        break;
+      }
+
+      uint8_t buffer[6];
+      ASSERT(Wire.readBytes(buffer, sizeof(buffer) / sizeof(buffer[0])) == sizeof(buffer) / sizeof(buffer[0]));
+      const int16_t x = ((int16_t)buffer[0]) | (((int16_t)buffer[1]) << 8);
+      const int16_t y = ((int16_t)buffer[2]) | (((int16_t)buffer[3]) << 8);
+      const int16_t z = ((int16_t)buffer[4]) | (((int16_t)buffer[5]) << 8);
+
+      switch(*in_progress_type) {
+        case VECTOR_RAW_ACCEL:
+          last_vector = Vector<3>(static_cast<float>(x) / 100.0, static_cast<float>(y) / 100.0, static_cast<float>(z) / 100.0);
+          break;
+        case VECTOR_EULER:
+          last_vector = Vector<3>(static_cast<float>(x) / 16.0, static_cast<float>(y) / 16.0, static_cast<float>(z) / 16.0);
+          break;
+        case VECTOR_LINEAR_ACCEL:
+          last_vector = Vector<3>(static_cast<float>(x) / 100.0, static_cast<float>(y) / 100.0, static_cast<float>(z) / 100.0);
+          break;
+      }
+      break;
+  }
 }

--- a/hf1/arduino/bno055.cpp
+++ b/hf1/arduino/bno055.cpp
@@ -332,7 +332,7 @@ void BNO055::Run() {
       break;
 
     case State::kReadingData:
-      if (Wire.done()) { break; }
+      if (!Wire.done()) { break; }
       state_ = State::kIdle;
       const auto in_progress_type = GetVectorTypeOfTransferInProgress();
       ASSERT(in_progress_type.ok());

--- a/hf1/arduino/bno055.h
+++ b/hf1/arduino/bno055.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 #include "vector.h"
+#include "status_or.h"
 
 // Operation mode settings.
 typedef enum {
@@ -30,10 +31,41 @@ typedef enum {
 // Class handling communication with the BNO055 IMU.
 class BNO055 {
 public:
-  BNO055() {}
+  BNO055(uint8_t device_address);
+
+  // Initializes the IMU or dies if there's any error.
+  // Before reinitializing it, it wait until any pending asynchronous transfers finish.
   bool begin(BNO055OperationMode op_mode);
+
+  // Sets the operating mode of the IMU or dies if there's any error.
+  // Before changing the mode, it waits until any pending asynchronous transfers finish.
   void setMode(BNO055OperationMode op_mode);
-  Vector<3> getVector(TVectorType vector_type) const;
+
+  // Blocks until the requested vector type is received and returns it, or dies if there's any error.
+  // If there is a pending asynchronous transfer initiated with RequestVectorAsync(), this function waits for it to finish,
+  // and initiates a new one, if the requested vector type is different.
+  // The call dies upon transmission errors.
+  Vector<3> getVector(TVectorType vector_type);
+
+  // Initiates an asynchronous transfer of the passed vector type.
+  // This function returns immediately. Callers can call GetLastRequestedVector() to wait for the requested data.
+  // Before the requested data arrives, further calls to RequestVectorAsync() will fail.
+  // This function may return one of the following status codes: 
+  //  kSuccess - the transfer was initiated correctly.
+  //  kExistsError - there already exists an asynchronous operation in progress.
+  //  kUnavailableError - there was a communication error.
+  Status RequestVectorAsync(TVectorType vector_type);
+
+  // Gets the last vector of the given type requested with RequestVectorAsync(), if available. 
+  // This function may return one of the following status codes:
+  //  kSuccess - the vector is available and returned.
+  //  kUnavailableError - there was a communication error.
+  //  kInProgressError - the vector is being requested or transferred.
+  //  kDoesNotExistError - no asynchronous operation was started with RequestVectorAsync() for the given type.
+  StatusOr<Vector<3>> GetLastRequestedVector(TVectorType vector_type) const;
+
+  // Returns the vector type of the transfer in progress, if any, or kDoesNotExistError if no transfer is in progress.
+  StatusOr<TVectorType> GetVectorTypeOfTransferInProgress() const;
 
 #pragma pack(push, 1)
   struct CalibrationStatus {
@@ -50,7 +82,6 @@ public:
 
     bool IsFullyCalibrated() const;
   };
-  CalibrationStatus GetCalibrationStatus() const;
 
   struct CalibrationData {
     int16_t accel_offset_x;
@@ -69,11 +100,35 @@ public:
     int16_t mag_radius;
   };
 #pragma pack(pop)
-  CalibrationData GetCalibrationData() const;
-  void SetCalibrationData(const CalibrationData &data) const;
+
+  // Returns the calibration status of the IMU.
+  // Before requesting the calibration status, it waits until any pending asynchronous transfers finish.
+  CalibrationStatus GetCalibrationStatus();
+
+  // Returns the calibration data or dies if there's any error.
+  // Before requesting the calibration data, it waits until any pending asynchronous transfers finish.
+  CalibrationData GetCalibrationData();
+
+  // Sets the calibration data or dies if there's any error.
+  // Before setting the calibration data, it waits until any pending asynchronous transfers finish.
+  void SetCalibrationData(const CalibrationData &data);
+
+  // Handles the lifetime of asynchronous requests. Must be called periodically.
+  void Run();
+
+  // Blocks until the pending transfer finishes, if any.
+  void WaitForPendingTransferToFinish();
 
 private:
+  int GetLastVectorIndexFromVectorType(TVectorType type) const;
+  TVectorType GetVectorTypeFromLastVectorIndex(int index) const;
+
+  uint8_t device_address_;
   BNO055OperationMode last_mode_;
+  StatusOr<Vector<3>> last_vectors_[3];  
+
+  using State = enum { kIdle, kWaitingForRegisterAddressWritten, kReadingData };
+  State state_;
 };
 
 #endif  // BNO055_INCLUDED_

--- a/hf1/arduino/body_imu.h
+++ b/hf1/arduino/body_imu.h
@@ -1,12 +1,14 @@
 #include <status_or.h>
 #include "bno055.h"
 #include "vector.h"
+#include "status_or.h"
 
 class BodyIMU {
 public:
   BodyIMU();
 
   void Init();
+  void Run();
 
   // The reference frame for all the following functions is as follows:
   // x points to the front of the robot.
@@ -15,29 +17,51 @@ public:
 
   // Returns the orientation with respect to the initial pose, in ZYX euler angles.
   // Value ranges are: yaw (z): [-pi, pi), pitch (y): [-pi/2, pi/2), roll (x): [-pi, pi).
+  // Unlike its AsyncRequest*() counterpart, this function blocks until the result is available.
   Vector<3> GetYawPitchRoll();
 
   // Returns the linear accelerations in m/s^2.
+  // The function blocks until the result is available.
+  // Unlike its AsyncRequest*() counterpart, this function blocks until the result is available.
   Vector<3> GetLinearAccelerations();
 
   // Returns the raw accelerations in m/s^2.
+  // Unlike its AsyncRequest*() counterpart, this function blocks until the result is available.
   Vector<3> GetRawAccelerations();
 
-  // Returns the angular velocities in rad/s.
-  // imu::Vector<3> GetAngularVelocities();
+  // These functions are like their Get*() counterparts, but retrieve the result asynchronously.
+  // To get the result when available call their respective GetLast*() functions.
+  //  kSuccess - the vector was requested correctly.
+  //  kUnavailablError - there was an error requesting the vector.
+  //  kExistsError - there already exists an asynchronous operation in progress.
+  Status AsyncRequestYawPitchRoll();
+  Status AsyncRequestLinearAccelerations();
+  Status AsyncRequestRawAccelerations();
 
+  // These functions get the vectors requested with the last call to the respective AsyncRequest*(), if available.
+  // They may return the following status codes:
+  //  kInProgressError - the vector is being retrieved.
+  //  kSuccess - the vector was received and is returned.
+  //  kUnavailablError - there was an error retrieving the vector.
+  //  kDoesNotExistError - no asynchronous operation was started with AsyncRequest*() to retrieve the vector.
+  StatusOr<Vector<3>> GetLastYawPitchRoll();
+  StatusOr<Vector<3>> GetLastLinearAccelerations();
+  StatusOr<Vector<3>> GetLastRawAccelerations();
+
+  // All the following functions wait until the pending asynchronous request is complete, if any.
   void StartCalibration();
   using CalibrationStatus = BNO055::CalibrationStatus;
-  CalibrationStatus GetCalibrationStatus() const;
+  CalibrationStatus GetCalibrationStatus();
   using CalibrationData = BNO055::CalibrationData;
-  CalibrationData GetCalibrationData() const;
+  CalibrationData GetCalibrationData();
   bool SaveCalibrationData();
   bool LoadCalibrationData();
-  bool IsCalibrated() const;
+  bool IsCalibrated();
   void StopCalibration();
 
 private:
   BNO055 bno055_;
+  Vector<3> CanonicalizeEulerVector(const Vector<3> &vector);
 };
 
 extern BodyIMU body_imu;

--- a/hf1/arduino/checks.h
+++ b/hf1/arduino/checks.h
@@ -8,5 +8,5 @@ bool CheckEEPROM(Stream &stream = null_stream);
 bool CheckTimer(Stream &stream = null_stream);
 bool CheckMotors(Stream &stream = null_stream, bool check_preconditions = false);
 bool CheckEncoders(Stream &stream, bool check_preconditions = false);
-bool CheckBodyIMU(Stream &stream, bool check_preconditions = false);
-bool CheckBodyMotion(Stream &stream, bool check_preconditions = false);
+bool CheckBaseIMU(Stream &stream, bool check_preconditions = false);
+bool CheckBaseMotion(Stream &stream, bool check_preconditions = false);

--- a/hf1/arduino/console.cpp
+++ b/hf1/arduino/console.cpp
@@ -12,6 +12,7 @@
 #include "wheel_state_estimator.h"
 #include "operation_mode.h"
 #include "base_controller.h"
+#include "robot_state_estimator.h"
 
 extern TimerArduino timer;
 extern WheelSpeedController left_wheel;
@@ -265,6 +266,11 @@ void ReadBaseIMUAccelerationCommandHandler::Help(Stream &stream, const CommandLi
   stream.println("The x axis points to robot's front.");
   stream.println("The y axis points to robot's left.");
   stream.println("The z axis points to sky.");
+}
+
+void ReadBaseStateCommandHandler::Run(Stream &stream, const CommandLine &command_line) {
+  const auto base_state = GetBaseState();
+  stream.printf("location: (%.3f, %.3f, %.3f) ; velocity: (%.3f, %.3f, %.3f)\n", base_state.location().position().x, base_state.location().position().y, base_state.location().yaw(), base_state.velocity().position().x, base_state.velocity().position().y, base_state.velocity().yaw());
 }
 
 void ReadTimerTicksCommandHandler::Run(Stream &stream, const CommandLine &command_line) {

--- a/hf1/arduino/console.cpp
+++ b/hf1/arduino/console.cpp
@@ -2,7 +2,7 @@
 #include "console.h"
 #include "battery.h"
 #include "status_or.h"
-#include "body_imu.h"
+#include "base_imu.h"
 #include "motors.h"
 #include "checks.h"
 #include "servos.h"
@@ -60,12 +60,12 @@ StatusOr<TimerNanosType> NanosFromDurationString(const StringView &s) {
   return period_ns;
 }
 
-void PrintBodyIMUCalibrationStatus(Stream &stream, const BodyIMU::CalibrationStatus &status) {
+void PrintBaseIMUCalibrationStatus(Stream &stream, const BaseIMU::CalibrationStatus &status) {
   static const char done_str[] = " (done)";
   static const char incomplete_str[] = "";
   static const char yes_str[] = "YES";
   static const char no_str[] = "NO";
-  stream.printf("Body IMU calibrated: %s ; Details: system=%d%s gyroscopes=%d%s accelerometers=%d%s magnetometer=%d%s\n", 
+  stream.printf("Base IMU calibrated: %s ; Details: system=%d%s gyroscopes=%d%s accelerometers=%d%s magnetometer=%d%s\n", 
     status.IsFullyCalibrated() ? yes_str : no_str,
     status.system, status.IsSystemCalibrated() ? done_str : incomplete_str, 
     status.gyroscopes, status.AreGyroscopesCalibrated() ? done_str : incomplete_str, 
@@ -73,7 +73,7 @@ void PrintBodyIMUCalibrationStatus(Stream &stream, const BodyIMU::CalibrationSta
     status.magnetometer, status.IsMagnetometerCalibrated() ? done_str : incomplete_str);
 }
 
-void PrintBodyIMUCalibrationData(Stream &stream, const BodyIMU::CalibrationData &data) {
+void PrintBaseIMUCalibrationData(Stream &stream, const BaseIMU::CalibrationData &data) {
   stream.printf("[Accelerometers]\n  Offsets: x=%d y=%d z=%d\n  Radius: %d\n[Gyroscopes]  Offsets: x=%d y=%d z=%d\n[Magnetometer]\n  Offsets: x=%d y=%d z=%d\n  Radius: %d\n", 
     data.accel_offset_x, data.accel_offset_y, data.accel_offset_z, data.accel_radius,
     data.gyro_offset_x, data.gyro_offset_y, data.gyro_offset_z, 
@@ -232,16 +232,16 @@ void ReadBatteryCommandHandler::Describe(Stream &stream, const CommandLine &comm
   stream.println("Prints the battery voltage.");
 }
 
-void ReadBodyIMUOrientationCommandHandler::Run(Stream &stream, const CommandLine &command_line) {
-  const auto ypr = body_imu.GetYawPitchRoll();
+void ReadBaseIMUOrientationCommandHandler::Run(Stream &stream, const CommandLine &command_line) {
+  const auto ypr = base_imu.GetYawPitchRoll();
   stream.printf("yaw:%f, pitch:%f, roll:%f [radians]\n", ypr.z(), ypr.y(), ypr.x());
 }
 
-void ReadBodyIMUOrientationCommandHandler::Describe(Stream &stream, const CommandLine &command_line) {
+void ReadBaseIMUOrientationCommandHandler::Describe(Stream &stream, const CommandLine &command_line) {
   stream.println("Orientation in yaw, pitch, roll euler angles, in radians.");
 }
 
-void ReadBodyIMUOrientationCommandHandler::Help(Stream &stream, const CommandLine &command_line) {
+void ReadBaseIMUOrientationCommandHandler::Help(Stream &stream, const CommandLine &command_line) {
   Describe(stream, command_line);
   stream.println("Every eurler angle is rotation around an axis of the reference frame, following the right hand rule.");
   stream.println("The reference frame is located at the center of the robot.");
@@ -250,16 +250,16 @@ void ReadBodyIMUOrientationCommandHandler::Help(Stream &stream, const CommandLin
   stream.println("The z axis points to sky.");
 }
 
-void ReadBodyIMUAccelerationCommandHandler::Run(Stream &stream, const CommandLine &command_line) {
-  const auto acceleration = body_imu.GetLinearAccelerations();
+void ReadBaseIMUAccelerationCommandHandler::Run(Stream &stream, const CommandLine &command_line) {
+  const auto acceleration = base_imu.GetLinearAccelerations();
   stream.printf("(%f, %f, %f) m/s^2\n", acceleration.x(), acceleration.y(), acceleration.z());
 }
 
-void ReadBodyIMUAccelerationCommandHandler::Describe(Stream &stream, const CommandLine &command_line) {
+void ReadBaseIMUAccelerationCommandHandler::Describe(Stream &stream, const CommandLine &command_line) {
   stream.println("Acceleration vector: (x, y, z) m/s^2.");
 }
 
-void ReadBodyIMUAccelerationCommandHandler::Help(Stream &stream, const CommandLine &command_line) {
+void ReadBaseIMUAccelerationCommandHandler::Help(Stream &stream, const CommandLine &command_line) {
   Describe(stream, command_line);
   stream.println("The reference frame is located at the center of the robot.");
   stream.println("The x axis points to robot's front.");
@@ -343,20 +343,20 @@ void ReadEncodersLinearSpeedCommandHandler::Describe(Stream &stream, const Comma
   stream.println("Reads the linear speed of the wheels estimated with the encoders.");
 }
 
-void ReadBodyIMUCalibrationDataCommandHandler::Run(Stream &stream, const CommandLine &command_line) {
-  PrintBodyIMUCalibrationData(stream, body_imu.GetCalibrationData());
+void ReadBaseIMUCalibrationDataCommandHandler::Run(Stream &stream, const CommandLine &command_line) {
+  PrintBaseIMUCalibrationData(stream, base_imu.GetCalibrationData());
 }
 
-void ReadBodyIMUCalibrationDataCommandHandler::Describe(Stream &stream, const CommandLine &command_line) {
-  stream.println("Reads the calibration data of the body IMU.");
+void ReadBaseIMUCalibrationDataCommandHandler::Describe(Stream &stream, const CommandLine &command_line) {
+  stream.println("Reads the calibration data of the base IMU.");
 }
 
-void ReadBodyIMUCalibrationStatusCommandHandler::Run(Stream &stream, const CommandLine &command_line) {
-  PrintBodyIMUCalibrationStatus(stream, body_imu.GetCalibrationStatus());
+void ReadBaseIMUCalibrationStatusCommandHandler::Run(Stream &stream, const CommandLine &command_line) {
+  PrintBaseIMUCalibrationStatus(stream, base_imu.GetCalibrationStatus());
 }
 
-void ReadBodyIMUCalibrationStatusCommandHandler::Describe(Stream &stream, const CommandLine &command_line) {
-  stream.println("Reads the calibration status of different subsystems of the body IMU.");
+void ReadBaseIMUCalibrationStatusCommandHandler::Describe(Stream &stream, const CommandLine &command_line) {
+  stream.println("Reads the calibration status of different subsystems of the base IMU.");
 }
 
 void WriteMotorsPWMCommandHandler::Run(Stream &stream, const CommandLine &command_line) {
@@ -601,30 +601,30 @@ void CheckEncodersCommandHandler::Describe(Stream &stream, const CommandLine &co
   stream.println("Waits for you to rotate the wheels to check encoder signals.");
 }
 
-void CheckBodyIMUCommandHandler::Run(Stream &stream, const CommandLine &command_line) {
-  CheckBodyIMU(stream, /*check_preconditions*/true);
+void CheckBaseIMUCommandHandler::Run(Stream &stream, const CommandLine &command_line) {
+  CheckBaseIMU(stream, /*check_preconditions*/true);
 }
 
-void CheckBodyIMUCommandHandler::Describe(Stream &stream, const CommandLine &command_line) {
+void CheckBaseIMUCommandHandler::Describe(Stream &stream, const CommandLine &command_line) {
   stream.println("Waits for you to move the robot as instructed to check the IMU output.");
 }
 
-void CheckBodyMotionCommandHandler::Run(Stream &stream, const CommandLine &command_line) {
-  CheckBodyMotion(stream, /*check_preconditions*/true);
+void CheckBaseMotionCommandHandler::Run(Stream &stream, const CommandLine &command_line) {
+  CheckBaseMotion(stream, /*check_preconditions*/true);
 }
 
-void CheckBodyMotionCommandHandler::Describe(Stream &stream, const CommandLine &command_line) {
-  stream.println("Checks the base motion system by activating the motors and monitoring the readings from the wheel encoders and the body IMU.");
+void CheckBaseMotionCommandHandler::Describe(Stream &stream, const CommandLine &command_line) {
+  stream.println("Checks the base motion system by activating the motors and monitoring the readings from the wheel encoders and the base IMU.");
 }
 
-void CalibrateBodyIMUCommandHandler::Run(Stream &stream, const CommandLine &command_line) {
-  body_imu.StartCalibration();
+void CalibrateBaseIMUCommandHandler::Run(Stream &stream, const CommandLine &command_line) {
+  base_imu.StartCalibration();
   TimerSecondsType last_print_seconds_ = GetTimerSeconds();
   while(!stream.available()) {
-    const auto status = body_imu.GetCalibrationStatus();
+    const auto status = base_imu.GetCalibrationStatus();
     const auto now = GetTimerSeconds();
     if (now - last_print_seconds_ >= 0.5) {
-      PrintBodyIMUCalibrationStatus(stream, status);
+      PrintBaseIMUCalibrationStatus(stream, status);
       last_print_seconds_ = now;
     }
     if (status.IsFullyCalibrated()) {
@@ -635,24 +635,24 @@ void CalibrateBodyIMUCommandHandler::Run(Stream &stream, const CommandLine &comm
     stream.read();    
   }
 
-  if (!body_imu.IsCalibrated()) {
-    body_imu.StopCalibration();
+  if (!base_imu.IsCalibrated()) {
+    base_imu.StopCalibration();
     stream.println("ERROR: Calibration interrupted by user.");
     return;
   }
   
-  body_imu.StopCalibration();
-  PrintBodyIMUCalibrationStatus(stream, body_imu.GetCalibrationStatus());
+  base_imu.StopCalibration();
+  PrintBaseIMUCalibrationStatus(stream, base_imu.GetCalibrationStatus());
 
   stream.print("Saving calibration data to EEPROM");
-  if (body_imu.SaveCalibrationData()) { stream.println(": OK."); }
+  if (base_imu.SaveCalibrationData()) { stream.println(": OK."); }
   else { stream.println(": ERROR."); }
 
   stream.println("OK.");
 }
 
-void CalibrateBodyIMUCommandHandler::Describe(Stream &stream, const CommandLine &command_line) {
-  stream.println("Runs the calibration routine of the body IMU.");
+void CalibrateBaseIMUCommandHandler::Describe(Stream &stream, const CommandLine &command_line) {
+  stream.println("Runs the calibration routine of the base IMU.");
 }
 
 void ResetMCUCommandHandler::Run(Stream &stream, const CommandLine &command_line) {

--- a/hf1/arduino/console.h
+++ b/hf1/arduino/console.h
@@ -160,67 +160,67 @@ public:
   void Describe(Stream &stream, const CommandLine &command_line) override;
 };
 
-class ReadBodyIMUOrientationCommandHandler : public CommandHandler {
+class ReadBaseIMUOrientationCommandHandler : public CommandHandler {
 public:
-  ReadBodyIMUOrientationCommandHandler() : CommandHandler("orientation") {}
+  ReadBaseIMUOrientationCommandHandler() : CommandHandler("orientation") {}
 
   void Run(Stream &stream, const CommandLine &command_line) override;
   void Describe(Stream &stream, const CommandLine &command_line) override;  
   void Help(Stream &stream, const CommandLine &command_line) override;  
 };
 
-class ReadBodyIMUAccelerationCommandHandler : public CommandHandler {
+class ReadBaseIMUAccelerationCommandHandler : public CommandHandler {
 public:
-  ReadBodyIMUAccelerationCommandHandler() : CommandHandler("acceleration") {}
+  ReadBaseIMUAccelerationCommandHandler() : CommandHandler("acceleration") {}
 
   void Run(Stream &stream, const CommandLine &command_line) override;
   void Describe(Stream &stream, const CommandLine &command_line) override;  
   void Help(Stream &stream, const CommandLine &command_line) override;  
 };
 
-class ReadBodyIMUCalibrationStatusCommandHandler : public CommandHandler {
+class ReadBaseIMUCalibrationStatusCommandHandler : public CommandHandler {
 public:
-  ReadBodyIMUCalibrationStatusCommandHandler() : CommandHandler("status") {}
+  ReadBaseIMUCalibrationStatusCommandHandler() : CommandHandler("status") {}
 
   void Run(Stream &stream, const CommandLine &command_line) override;
   void Describe(Stream &stream, const CommandLine &command_line) override;  
 };
 
-class ReadBodyIMUCalibrationDataCommandHandler : public CommandHandler {
+class ReadBaseIMUCalibrationDataCommandHandler : public CommandHandler {
 public:
-  ReadBodyIMUCalibrationDataCommandHandler() : CommandHandler("data") {}
+  ReadBaseIMUCalibrationDataCommandHandler() : CommandHandler("data") {}
 
   void Run(Stream &stream, const CommandLine &command_line) override;
   void Describe(Stream &stream, const CommandLine &command_line) override;  
 };
 
-class ReadBodyIMUCalibrationCommandHandler : public CategoryHandler {
+class ReadBaseIMUCalibrationCommandHandler : public CategoryHandler {
 public:
-  ReadBodyIMUCalibrationCommandHandler() 
-    : CategoryHandler("calibration", { &read_body_imu_calibration_status_handler_, &read_body_imu_calibration_data_handler_ }) {}
+  ReadBaseIMUCalibrationCommandHandler() 
+    : CategoryHandler("calibration", { &read_base_imu_calibration_status_handler_, &read_base_imu_calibration_data_handler_ }) {}
 
   void Describe(Stream &stream, const CommandLine &command_line) override {
-    stream.println("Reads calibration properties from the body IMU.");
+    stream.println("Reads calibration properties from the base IMU.");
   }
 
 private:
-  ReadBodyIMUCalibrationStatusCommandHandler read_body_imu_calibration_status_handler_;
-  ReadBodyIMUCalibrationDataCommandHandler read_body_imu_calibration_data_handler_;
+  ReadBaseIMUCalibrationStatusCommandHandler read_base_imu_calibration_status_handler_;
+  ReadBaseIMUCalibrationDataCommandHandler read_base_imu_calibration_data_handler_;
 };
 
-class ReadBodyIMUCommandHandler : public CategoryHandler {
+class ReadBaseIMUCommandHandler : public CategoryHandler {
 public:
-  ReadBodyIMUCommandHandler() 
-    : CategoryHandler("body_imu", { &read_bodyimu_orientation_, &read_bodyimu_acceleration_, &read_bodyimu_calibration_ }) {}
+  ReadBaseIMUCommandHandler() 
+    : CategoryHandler("base_imu", { &read_baseimu_orientation_, &read_baseimu_acceleration_, &read_baseimu_calibration_ }) {}
 
   void Describe(Stream &stream, const CommandLine &command_line) override {
-    stream.println("Reads from the IMU at the robot's body.");    
+    stream.println("Reads from the IMU at the robot's base.");    
   }
 
 private:
-  ReadBodyIMUOrientationCommandHandler read_bodyimu_orientation_;
-  ReadBodyIMUAccelerationCommandHandler read_bodyimu_acceleration_;
-  ReadBodyIMUCalibrationCommandHandler read_bodyimu_calibration_;
+  ReadBaseIMUOrientationCommandHandler read_baseimu_orientation_;
+  ReadBaseIMUAccelerationCommandHandler read_baseimu_acceleration_;
+  ReadBaseIMUCalibrationCommandHandler read_baseimu_calibration_;
 };
 
 class ReadTimerUnitsCommandHandler : public CommandHandler {
@@ -394,7 +394,7 @@ private:
 class ReadCommandHandler : public CategoryHandler {
 public:
   ReadCommandHandler()
-    : CategoryHandler("read", { &read_timer_handler_, &read_global_timer_handler_, &read_battery_handler_, &read_bodyimu_handler_, &read_encoders_handler_ }) {}
+    : CategoryHandler("read", { &read_timer_handler_, &read_global_timer_handler_, &read_battery_handler_, &read_baseimu_handler_, &read_encoders_handler_ }) {}
 
   void Describe(Stream &stream, const CommandLine &command_line) override {
     stream.println("Reads from an information source on the robot.");    
@@ -404,7 +404,7 @@ private:
   ReadTimerCommandHandler read_timer_handler_;
   ReadGlobalTimerCommandHandler read_global_timer_handler_;
   ReadBatteryCommandHandler read_battery_handler_;
-  ReadBodyIMUCommandHandler read_bodyimu_handler_;
+  ReadBaseIMUCommandHandler read_baseimu_handler_;
   ReadEncodersCommandHandler read_encoders_handler_;
 };
 
@@ -571,17 +571,17 @@ public:
   void Describe(Stream &stream, const CommandLine &command_line) override;
 };
 
-class CheckBodyIMUCommandHandler : public CommandHandler {
+class CheckBaseIMUCommandHandler : public CommandHandler {
 public:
-  CheckBodyIMUCommandHandler() : CommandHandler("body_imu") {}
+  CheckBaseIMUCommandHandler() : CommandHandler("base_imu") {}
 
   void Run(Stream &stream, const CommandLine &command_line) override;
   void Describe(Stream &stream, const CommandLine &command_line) override;
 };
 
-class CheckBodyMotionCommandHandler : public CommandHandler {
+class CheckBaseMotionCommandHandler : public CommandHandler {
 public:
-  CheckBodyMotionCommandHandler() : CommandHandler("body_motion") {}
+  CheckBaseMotionCommandHandler() : CommandHandler("base_motion") {}
 
   void Run(Stream &stream, const CommandLine &command_line) override;
   void Describe(Stream &stream, const CommandLine &command_line) override;
@@ -592,8 +592,8 @@ public:
   CheckCommandHandler()
     : CategoryHandler("check", { 
       &check_mcu_handler_, &check_sram_handler_, &check_eeprom_handler_, &check_timer_handler_, &check_battery_handler_, 
-      &check_motors_handler_, &check_encoders_handler_, &check_body_imu_command_handler_,
-      &check_body_motion_command_handler_ }) {}
+      &check_motors_handler_, &check_encoders_handler_, &check_base_imu_command_handler_,
+      &check_base_motion_command_handler_ }) {}
 
   void Describe(Stream &stream, const CommandLine &command_line) override {
     stream.println("Checks different subsystems on the robot.");    
@@ -607,13 +607,13 @@ private:
   CheckBatteryCommandHandler check_battery_handler_;
   CheckMotorsCommandHandler check_motors_handler_;
   CheckEncodersCommandHandler check_encoders_handler_;
-  CheckBodyIMUCommandHandler check_body_imu_command_handler_;
-  CheckBodyMotionCommandHandler check_body_motion_command_handler_;
+  CheckBaseIMUCommandHandler check_base_imu_command_handler_;
+  CheckBaseMotionCommandHandler check_base_motion_command_handler_;
 };
 
-class CalibrateBodyIMUCommandHandler : public CommandHandler {
+class CalibrateBaseIMUCommandHandler : public CommandHandler {
 public:
-  CalibrateBodyIMUCommandHandler() : CommandHandler("body_imu") {}
+  CalibrateBaseIMUCommandHandler() : CommandHandler("base_imu") {}
 
   void Run(Stream &stream, const CommandLine &command_line) override;
   void Describe(Stream &stream, const CommandLine &command_line) override;
@@ -621,14 +621,14 @@ public:
 
 class CalibrateCommandHandler : public CategoryHandler {
 public:
-  CalibrateCommandHandler() : CategoryHandler("calibrate", { &calibrate_body_imu_handler_ }) {}
+  CalibrateCommandHandler() : CategoryHandler("calibrate", { &calibrate_base_imu_handler_ }) {}
 
   void Describe(Stream &stream, const CommandLine &command_line) override {
     stream.println("Calibrates different subsystems on the robot.");    
   }
 
 private:
-  CalibrateBodyIMUCommandHandler calibrate_body_imu_handler_;
+  CalibrateBaseIMUCommandHandler calibrate_base_imu_handler_;
 };
 
 class ResetMCUCommandHandler : public CommandHandler {

--- a/hf1/arduino/console.h
+++ b/hf1/arduino/console.h
@@ -223,17 +223,32 @@ private:
   ReadBaseIMUCalibrationCommandHandler read_baseimu_calibration_;
 };
 
+class ReadBaseStateCommandHandler : public CommandHandler {
+public:
+  ReadBaseStateCommandHandler() : CommandHandler("state") {}
+
+  void Run(Stream &stream, const CommandLine &command_line) override;
+  void Describe(Stream &stream, const CommandLine &command_line) override {
+    stream.println("Prints the estimated state of the base, including location and velocity with respect to where the MCU booted up.");
+  }
+  void Help(Stream &stream, const CommandLine &command_line) override {
+    stream.println("Prints the estimated state of the base in the following format:");
+    stream.println("location: (x, y, yaw) ; velocity: (vx, vy, vyaw)");
+  }
+};
+
 class ReadBaseCommandHandler : public CategoryHandler {
 public:
   ReadBaseCommandHandler() 
-    : CategoryHandler("base", { &read_baseimu_command_handler_ }) {}
+    : CategoryHandler("base", { &read_base_imu_command_handler_, &read_base_state_command_handler_ }) {}
 
   void Describe(Stream &stream, const CommandLine &command_line) override {
-    stream.println("Reads from information sources at the robot's base.");    
+    stream.println("Reads information on the robot's base.");    
   }
 
 private:
-  ReadBaseIMUCommandHandler read_baseimu_command_handler_;
+  ReadBaseIMUCommandHandler read_base_imu_command_handler_;
+  ReadBaseStateCommandHandler read_base_state_command_handler_;
 };
 
 class ReadTimerUnitsCommandHandler : public CommandHandler {

--- a/hf1/arduino/console.h
+++ b/hf1/arduino/console.h
@@ -211,7 +211,7 @@ private:
 class ReadBaseIMUCommandHandler : public CategoryHandler {
 public:
   ReadBaseIMUCommandHandler() 
-    : CategoryHandler("base_imu", { &read_baseimu_orientation_, &read_baseimu_acceleration_, &read_baseimu_calibration_ }) {}
+    : CategoryHandler("imu", { &read_baseimu_orientation_, &read_baseimu_acceleration_, &read_baseimu_calibration_ }) {}
 
   void Describe(Stream &stream, const CommandLine &command_line) override {
     stream.println("Reads from the IMU at the robot's base.");    
@@ -221,6 +221,19 @@ private:
   ReadBaseIMUOrientationCommandHandler read_baseimu_orientation_;
   ReadBaseIMUAccelerationCommandHandler read_baseimu_acceleration_;
   ReadBaseIMUCalibrationCommandHandler read_baseimu_calibration_;
+};
+
+class ReadBaseCommandHandler : public CategoryHandler {
+public:
+  ReadBaseCommandHandler() 
+    : CategoryHandler("base", { &read_baseimu_command_handler_ }) {}
+
+  void Describe(Stream &stream, const CommandLine &command_line) override {
+    stream.println("Reads from information sources at the robot's base.");    
+  }
+
+private:
+  ReadBaseIMUCommandHandler read_baseimu_command_handler_;
 };
 
 class ReadTimerUnitsCommandHandler : public CommandHandler {
@@ -394,7 +407,7 @@ private:
 class ReadCommandHandler : public CategoryHandler {
 public:
   ReadCommandHandler()
-    : CategoryHandler("read", { &read_timer_handler_, &read_global_timer_handler_, &read_battery_handler_, &read_baseimu_handler_, &read_encoders_handler_ }) {}
+    : CategoryHandler("read", { &read_timer_handler_, &read_global_timer_handler_, &read_battery_handler_, &read_base_handler_, &read_encoders_handler_ }) {}
 
   void Describe(Stream &stream, const CommandLine &command_line) override {
     stream.println("Reads from an information source on the robot.");    
@@ -404,7 +417,7 @@ private:
   ReadTimerCommandHandler read_timer_handler_;
   ReadGlobalTimerCommandHandler read_global_timer_handler_;
   ReadBatteryCommandHandler read_battery_handler_;
-  ReadBaseIMUCommandHandler read_baseimu_handler_;
+  ReadBaseCommandHandler read_base_handler_;
   ReadEncodersCommandHandler read_encoders_handler_;
 };
 
@@ -573,7 +586,7 @@ public:
 
 class CheckBaseIMUCommandHandler : public CommandHandler {
 public:
-  CheckBaseIMUCommandHandler() : CommandHandler("base_imu") {}
+  CheckBaseIMUCommandHandler() : CommandHandler("imu") {}
 
   void Run(Stream &stream, const CommandLine &command_line) override;
   void Describe(Stream &stream, const CommandLine &command_line) override;
@@ -581,10 +594,25 @@ public:
 
 class CheckBaseMotionCommandHandler : public CommandHandler {
 public:
-  CheckBaseMotionCommandHandler() : CommandHandler("base_motion") {}
+  CheckBaseMotionCommandHandler() : CommandHandler("motion") {}
 
   void Run(Stream &stream, const CommandLine &command_line) override;
   void Describe(Stream &stream, const CommandLine &command_line) override;
+};
+
+class CheckBaseCommandHandler : public CategoryHandler {
+public:
+  CheckBaseCommandHandler()
+    : CategoryHandler("base", {       
+      &check_base_imu_command_handler_, &check_base_motion_command_handler_ }) {}
+
+  void Describe(Stream &stream, const CommandLine &command_line) override {
+    stream.println("Checks different subsystems on the robot's base.");    
+  }
+
+private:
+  CheckBaseIMUCommandHandler check_base_imu_command_handler_;
+  CheckBaseMotionCommandHandler check_base_motion_command_handler_;
 };
 
 class CheckCommandHandler : public CategoryHandler {
@@ -592,8 +620,7 @@ public:
   CheckCommandHandler()
     : CategoryHandler("check", { 
       &check_mcu_handler_, &check_sram_handler_, &check_eeprom_handler_, &check_timer_handler_, &check_battery_handler_, 
-      &check_motors_handler_, &check_encoders_handler_, &check_base_imu_command_handler_,
-      &check_base_motion_command_handler_ }) {}
+      &check_motors_handler_, &check_encoders_handler_, &check_base_command_handler_ }) {}
 
   void Describe(Stream &stream, const CommandLine &command_line) override {
     stream.println("Checks different subsystems on the robot.");    
@@ -607,28 +634,39 @@ private:
   CheckBatteryCommandHandler check_battery_handler_;
   CheckMotorsCommandHandler check_motors_handler_;
   CheckEncodersCommandHandler check_encoders_handler_;
-  CheckBaseIMUCommandHandler check_base_imu_command_handler_;
-  CheckBaseMotionCommandHandler check_base_motion_command_handler_;
+  CheckBaseCommandHandler check_base_command_handler_;
 };
 
 class CalibrateBaseIMUCommandHandler : public CommandHandler {
 public:
-  CalibrateBaseIMUCommandHandler() : CommandHandler("base_imu") {}
+  CalibrateBaseIMUCommandHandler() : CommandHandler("imu") {}
 
   void Run(Stream &stream, const CommandLine &command_line) override;
   void Describe(Stream &stream, const CommandLine &command_line) override;
 };
 
+class CalibrateBaseCommandHandler : public CategoryHandler {
+public:
+  CalibrateBaseCommandHandler() : CategoryHandler("base", { &calibrate_base_imu_handler_ }) {}
+
+  void Describe(Stream &stream, const CommandLine &command_line) override {
+    stream.println("Calibrates different subsystems on the robot's base.");
+  }
+
+private:
+  CalibrateBaseIMUCommandHandler calibrate_base_imu_handler_;
+};
+
 class CalibrateCommandHandler : public CategoryHandler {
 public:
-  CalibrateCommandHandler() : CategoryHandler("calibrate", { &calibrate_base_imu_handler_ }) {}
+  CalibrateCommandHandler() : CategoryHandler("calibrate", { &calibrate_base_handler_ }) {}
 
   void Describe(Stream &stream, const CommandLine &command_line) override {
     stream.println("Calibrates different subsystems on the robot.");    
   }
 
 private:
-  CalibrateBaseIMUCommandHandler calibrate_base_imu_handler_;
+  CalibrateBaseCommandHandler calibrate_base_handler_;
 };
 
 class ResetMCUCommandHandler : public CommandHandler {

--- a/hf1/arduino/robot_state_estimator.cpp
+++ b/hf1/arduino/robot_state_estimator.cpp
@@ -106,6 +106,8 @@ static int CompareEventPointers(const void *p1, const void *p2) {
 }
 
 void RunRobotStateEstimator() {
+  body_imu.Run();
+  
   const TimerNanosType now_ns = GetTimerNanoseconds();
   if (now_ns - last_imu_poll_time_ns >= kMinIMUPollingPeriodNs) {
     last_imu_poll_time_ns = now_ns;

--- a/hf1/common/status_or.h
+++ b/hf1/common/status_or.h
@@ -4,7 +4,7 @@
 #include "logger_interface.h"
 
 enum Status {
-  kSuccess, kUnavailableError, kMalformedError, kExistsError, kDoesNotExistError
+  kSuccess, kUnavailableError, kMalformedError, kExistsError, kDoesNotExistError, kInProgressError
 };
 
 template<typename ValueType> class StatusOr {


### PR DESCRIPTION
Changes in this PR:
* Polling the base IMU from the state estimator is done asynchronously, which minimizes blocking time and is friendly to other modules running concurrently, increasing processor utilization.
* The term "body" to refer to the robot's mobile base is replaced with "base" everywhere.
* "base" is now a command category everywhere instead of prefixing other objects, e.g. "base_imu" -> "base imu"
* New console command reads the base's state.