### PR TITLE
Allow caller of P2PByteStreamLinux to amend serial port upon physical I/O error.

### DIFF
--- a/hf1/arduino/p2p_byte_stream_arduino.h
+++ b/hf1/arduino/p2p_byte_stream_arduino.h
@@ -8,7 +8,7 @@ class P2PByteStreamArduino : public P2PByteStreamInterface<kLittleEndian> {
 public:
   // Does not take ownership of the stream, which must outlive this object.
   P2PByteStreamArduino(Stream *stream) 
-    : P2PByteStreamInterface<kLittleEndian>(Handler{ .object = stream}) {}
+    : P2PByteStreamInterface<kLittleEndian>(Handler{ .object = stream}, [](){}) {}
 
   virtual int Write(const void *buffer, int length);
   virtual int Read(void *buffer, int length);

--- a/hf1/common/p2p_byte_stream_interface.h
+++ b/hf1/common/p2p_byte_stream_interface.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 #include "network.h"
+#include <functional>
 
 #define kMaxPortNameLength 64
 
@@ -19,7 +20,8 @@ public:
 
   // Creates a byte transfer object with the platform-specific handler.
   // The handler must have been initialized with the proper configuration before this call.
-  P2PByteStreamInterface(Handler handler) : handler_(handler) {}
+  // The callback is called whenever there is a physical I/O error.
+  P2PByteStreamInterface(Handler handler, std::function<void()> &&physical_io_error_callback) : handler_(handler), physical_io_error_callback_(std::move(physical_io_error_callback)) {}
 
   // Attempts to send a maximum of `length` bytes in the buffer through the link, and returns the 
   // number of bytes actually sent. This call never blocks.
@@ -57,9 +59,11 @@ public:
 
 protected:
   const Handler &handler() const { return handler_; }
+  const std::function<void()>&physical_io_error_callback() { return physical_io_error_callback_; }
 
 private:
   Handler handler_;
+  std::function<void()> physical_io_error_callback_;
 };
 
 #endif  // P2P_BYTE_STREAM_INTERFACE__

--- a/hf1/common/status_or.h
+++ b/hf1/common/status_or.h
@@ -4,7 +4,7 @@
 #include "logger_interface.h"
 
 enum Status {
-  kSuccess, kUnavailableError, kMalformedError, kExistsError, kDoesNotExistError, kInProgressError
+  kSuccess, kUnavailableError, kMalformedError, kExistsError, kDoesNotExistError, kInProgressError, kInUseError
 };
 
 template<typename ValueType> class StatusOr {

--- a/hf1/linux/p2p_byte_stream_linux.cpp
+++ b/hf1/linux/p2p_byte_stream_linux.cpp
@@ -1,13 +1,20 @@
 #include "p2p_byte_stream_linux.h"
 #include <unistd.h>
+#include <errno.h>
 
 int P2PByteStreamLinux::Write(const void *buffer, int length) {
   int result = write(handler().fd, buffer, length);
+  if (result == -1 && errno == EIO) {
+    physical_io_error_callback()();
+  }
   return result != -1 ? result : 0;
 }
 
 int P2PByteStreamLinux::Read(void *buffer, int length) {
   int result = read(handler().fd, buffer, length);
+  if (result == -1 && errno == EIO) {
+    physical_io_error_callback()();
+  }
   return result != -1 ? result : 0;
 }
 

--- a/hf1/linux/p2p_byte_stream_linux.h
+++ b/hf1/linux/p2p_byte_stream_linux.h
@@ -2,9 +2,9 @@
 
 class P2PByteStreamLinux : public P2PByteStreamInterface<kLittleEndian> {
 public:
-  // Does not take ownership of the stream, which must outlive this object.
-  P2PByteStreamLinux(int fd) 
-    : P2PByteStreamInterface<kLittleEndian>(Handler{ .fd = fd}) {}
+  // Does not take ownership of the file descriptor, which must outlive this object.
+  P2PByteStreamLinux(int fd, std::function<void()> &&physical_io_error_callback) 
+    : P2PByteStreamInterface<kLittleEndian>(Handler{ .fd = fd}, std::move(physical_io_error_callback)) {}
 
   virtual int Write(const void *buffer, int length);
   virtual int Read(void *buffer, int length);

--- a/hf1/linux/uart.cpp
+++ b/hf1/linux/uart.cpp
@@ -11,12 +11,27 @@
 #define kSerialPath "/dev/ttyTHS1"
 #define kBaudRate B1000000
 
-Uart::Uart() {
+Uart::Uart() : fd_(-1) {
+}
+
+Uart::~Uart() {    
+  Close();
+}
+
+Status Uart::Open() {
+  Close();
+
 	fd_ = open(kSerialPath, O_RDWR | O_NONBLOCK);
-	ASSERTM(fd_ >= 0, "Error opening serial port");
+  if (fd_ < 0) {
+    return Status::kUnavailableError;
+  }
 
 	// Lock device file.
-	ASSERTM(flock(fd_, LOCK_EX | LOCK_NB) >= 0, "Error failed to lock device file");
+  if (flock(fd_, LOCK_EX | LOCK_NB) < 0) {
+    close(fd_);
+    fd_ = -1;
+    return Status::kInUseError;
+  }
 
 	struct termios newtio;
 	bzero(&newtio, sizeof(newtio));
@@ -38,12 +53,12 @@ Uart::Uart() {
 	tcsetattr(fd_, TCSANOW, &newtio);
 }
 
-Uart::~Uart() {    
-    if (fd_ >= 0) {
-        flock(fd_, LOCK_UN);
-        close(fd_);
-        fd_ = -1;
-    }
+void Uart::Close() {
+  if (fd_ >= 0) {
+      flock(fd_, LOCK_UN);
+      close(fd_);
+      fd_ = -1;
+  }
 }
 
 Uart::PollResult Uart::CanReadOrWrite(int timeout_ms) {

--- a/hf1/linux/uart.h
+++ b/hf1/linux/uart.h
@@ -1,12 +1,22 @@
 #ifndef UART_INCLUDED__
 #define UART_INCLUDED__
 
+#include "status_or.h"
+
 class Uart {
 public:
     enum Timeout { kInfinite = -1 };
 
     Uart();
     virtual ~Uart();
+
+    // Opens the serial port.
+    // Returns Status::kSuccess if ok, or the following errors otherwise:
+    //  Status::kUnavailableError - the port cannot be opened
+    //  Status::kInUseError - the port cannot be locked
+    Status Open();
+    // Closes the serial port.
+    void Close();
 
     struct PollResult {
         bool can_receive;


### PR DESCRIPTION
These changes enable the caller of P2PByteStreamLinux to amend the serial port (e.g. by reopening it) when a physical I/O error occurs. They are meant to support a fix for issue #20.

Summary of changes:
* P2PByteStreamInterface accepts a callback to notify of the physical I/O error.
* The Linux subclass calls the new callback when either read or write return -1 with errno EIO.
* The Arduino subclass does nothing with the new callback.
* Uart objects can be opened in closed after creation.