### PR TITLE
Cancel actions after motion controller restarts.

### DIFF
--- a/hf1/linux/p2p_action_client.cpp
+++ b/hf1/linux/p2p_action_client.cpp
@@ -23,7 +23,6 @@ Status P2PActionClientHandlerBase::Request(int payload_length, const void *paylo
   header->stage = P2PActionStage::kRequest;
   header->request_id = ++current_request_id_;
   memcpy(maybe_new_packet->content() + sizeof(P2PApplicationPacketHeader), payload, payload_length);
-  if (action_ == 5) { std::cout << "eoeoeoeo" << std::endl; };
   p2p_stream_.output().Commit(maybe_new_packet->priority(), guarantee_delivery.has_value() ? *guarantee_delivery : guarantee_delivery_);
 
   state_ = allows_concurrent_requests_ ? kIdle : kWaitingForResponse;
@@ -105,15 +104,16 @@ void P2PActionClientHandlerBase::Run() {
   header->action = action_;
   header->stage = P2PActionStage::kCancel;
   header->request_id = current_request_id_;
-  p2p_stream_.output().Commit(maybe_new_packet->priority(), guarantee_delivery_);
+  // There should be enough space in the output buffer to hold the cancellation packet.
+  ASSERT(p2p_stream_.output().Commit(maybe_new_packet->priority(), guarantee_delivery_));
 
   state_ = kIdle;
 
   OnAbort();
 }
 
-P2PActionClient::P2PActionClient(P2PPacketStreamLinux *p2p_stream, const TimerInterface *system_timer, std::mutex *p2p_mutex)
-  : p2p_stream_(*ASSERT_NOT_NULL(p2p_stream)), system_timer_(*ASSERT_NOT_NULL(system_timer)), p2p_mutex_(*ASSERT_NOT_NULL(p2p_mutex)) {
+P2PActionClient::P2PActionClient(P2PPacketStreamLinux *p2p_stream, const TimerInterface *system_timer)
+  : p2p_stream_(*ASSERT_NOT_NULL(p2p_stream)), system_timer_(*ASSERT_NOT_NULL(system_timer)) {
   p2p_stream_.other_end_started_callback(P2POtherEndStartedCallback(&P2PActionClient::OnOtherEndStarted, this));
   for (int i = 0; i < sizeof(handlers_) / sizeof(handlers_[0]); ++i) {
     handlers_[i] = nullptr;
@@ -192,10 +192,10 @@ void P2PActionClient::Run() {
 }
 
 void P2PActionClient::OnOtherEndStarted(void *p_self) {
+  // This is called as a callback from the p2p packet stream, so p2p_mutex_ is locked.
   ASSERT_NOT_NULL(p_self);
   P2PActionClient &self = *reinterpret_cast<P2PActionClient *>(p_self);
-  // Lock the mutex, so callbacks can alter the handlers' state.
-  // std::lock_guard<std::mutex> guard(self.p2p_mutex_);
+  // p2p_mutex_ is locked, so callbacks can alter the handlers' state without racing.
   for (int i = 0; i < sizeof(handlers_) / sizeof(handlers_[0]); ++i) {
     if (self.handlers_[i] != nullptr) {
       self.handlers_[i]->OnOtherEndStarted();

--- a/hf1/linux/p2p_action_client.cpp
+++ b/hf1/linux/p2p_action_client.cpp
@@ -23,6 +23,7 @@ Status P2PActionClientHandlerBase::Request(int payload_length, const void *paylo
   header->stage = P2PActionStage::kRequest;
   header->request_id = ++current_request_id_;
   memcpy(maybe_new_packet->content() + sizeof(P2PApplicationPacketHeader), payload, payload_length);
+  if (action_ == 5) { std::cout << "eoeoeoeo" << std::endl; };
   p2p_stream_.output().Commit(maybe_new_packet->priority(), guarantee_delivery.has_value() ? *guarantee_delivery : guarantee_delivery_);
 
   state_ = allows_concurrent_requests_ ? kIdle : kWaitingForResponse;
@@ -33,8 +34,16 @@ Status P2PActionClientHandlerBase::Cancel(std::optional<P2PPriority> priority, s
   // Protect with a mutex as this will be called from a different thread than Run().
   std::lock_guard<std::mutex> guard(p2p_mutex_);
 
-  if (!allows_concurrent_requests_ && state_ != kWaitingForResponse) {
-    return Status::kDoesNotExistError;
+  if (!allows_concurrent_requests_) {
+    if (state_ == kIdle) {
+      return Status::kDoesNotExistError;
+    } else {
+      if (state_ == kCancelling) {
+        // If we're already trying to cancel the action, tell the caller that they can move on,
+        // as the client will no longer be routing replies or progress to anybody.
+        return Status::kSuccess;
+      }
+    }
   }
 
   auto maybe_new_packet = p2p_stream_.output().NewPacket(priority.has_value() ? *priority : priority_);
@@ -58,23 +67,53 @@ bool P2PActionClientHandlerBase::in_progress() const {
 }
 
 void P2PActionClientHandlerBase::OnReply(int payload_length, const void *payload) {
-  // It is possible to get a reply after cancelling the action, if the cancellation arrives
-  // at the other end after it has sent the reply packet.
   // It is fine to modify state_ because this function is called only from Run(), which the caller calls with p2p_mutex_ locked.
   state_ = kIdle;  
 }
 
 void P2PActionClientHandlerBase::OnProgress(int payload_length, const void *payload) {
-  // It is possible to get a progress packet after cancelling the action, if the 
-  // cancellation arrives at the other end after it has sent the progress packet.
 }
 
 void P2PActionClientHandlerBase::OnOtherEndStarted() {
-  state_ = kIdle;
+  // If the other has restarted, the action might be gone and we might never get a reply. 
+  // However, if the action request was in the output buffer, the other end might get it
+  // after sending the handshake packet that triggered this callback, so we need to ensure
+  // that a cancellation is sent before marking it as cancelled locally. We the state as
+  // kCancelling, so Run() ensures that a cancellation packet is sent, after which the 
+  // action will be marked as kIdle, ready to be used again.
+  if (state_ == kWaitingForResponse) {
+    state_ = kCancelling;
+  }
 }
 
-P2PActionClient::P2PActionClient(P2PPacketStreamLinux *p2p_stream, const TimerInterface *system_timer)
-  : p2p_stream_(*ASSERT_NOT_NULL(p2p_stream)), system_timer_(*ASSERT_NOT_NULL(system_timer)) {
+void P2PActionClientHandlerBase::OnAbort() {
+}
+
+void P2PActionClientHandlerBase::Run() {
+  // This is called from the action client's Run(), so p2p_mutex_ is locked.
+
+  if (state_ != kCancelling) { return; }
+
+  // The action is being cancelled locally. Try to send the cancellation packet.
+  auto maybe_new_packet = p2p_stream_.output().NewPacket(priority_);
+  if (!maybe_new_packet.ok()) {
+    return;    
+  }
+
+  maybe_new_packet->length() = sizeof(P2PApplicationPacketHeader);
+  P2PApplicationPacketHeader *header = reinterpret_cast<P2PApplicationPacketHeader *>(maybe_new_packet->content());
+  header->action = action_;
+  header->stage = P2PActionStage::kCancel;
+  header->request_id = current_request_id_;
+  p2p_stream_.output().Commit(maybe_new_packet->priority(), guarantee_delivery_);
+
+  state_ = kIdle;
+
+  OnAbort();
+}
+
+P2PActionClient::P2PActionClient(P2PPacketStreamLinux *p2p_stream, const TimerInterface *system_timer, std::mutex *p2p_mutex)
+  : p2p_stream_(*ASSERT_NOT_NULL(p2p_stream)), system_timer_(*ASSERT_NOT_NULL(system_timer)), p2p_mutex_(*ASSERT_NOT_NULL(p2p_mutex)) {
   p2p_stream_.other_end_started_callback(P2POtherEndStartedCallback(&P2PActionClient::OnOtherEndStarted, this));
   for (int i = 0; i < sizeof(handlers_) / sizeof(handlers_[0]); ++i) {
     handlers_[i] = nullptr;
@@ -89,6 +128,14 @@ void P2PActionClient::Register(P2PActionClientHandlerBase *handler) {
 
 void P2PActionClient::Run() {
   // The caller is responsible for locking p2p_mutex_ before calling this function.
+
+  // Manage lifecycle of all actions by calling Run() on all handlers.
+  for (int i = 0; i < sizeof(handlers_) / sizeof(handlers_[0]); ++i) {
+    if (handlers_[i] != nullptr) {
+      handlers_[i]->Run();
+    }
+  }
+
   // Process new packets.
   const auto &maybe_packet = p2p_stream_.input().OldestPacket();
   if (!maybe_packet.ok()) {
@@ -119,6 +166,13 @@ void P2PActionClient::Run() {
     return;
   }
 
+  if (handler->state() != P2PActionClientHandlerBase::State::kWaitingForResponse) {
+    // The action is not waiting for a response because it was either not started 
+    // or it's being cancelled due to the other end having restarted.
+    p2p_stream_.input().Consume(maybe_packet->priority());
+    return;
+  }
+
   const uint8_t *payload = maybe_packet->content() + sizeof(P2PApplicationPacketHeader);
   switch(header->stage) {
     case P2PActionStage::kReply:
@@ -140,6 +194,8 @@ void P2PActionClient::Run() {
 void P2PActionClient::OnOtherEndStarted(void *p_self) {
   ASSERT_NOT_NULL(p_self);
   P2PActionClient &self = *reinterpret_cast<P2PActionClient *>(p_self);
+  // Lock the mutex, so callbacks can alter the handlers' state.
+  // std::lock_guard<std::mutex> guard(self.p2p_mutex_);
   for (int i = 0; i < sizeof(handlers_) / sizeof(handlers_[0]); ++i) {
     if (self.handlers_[i] != nullptr) {
       self.handlers_[i]->OnOtherEndStarted();

--- a/hf1/linux/p2p_action_client.h
+++ b/hf1/linux/p2p_action_client.h
@@ -14,6 +14,7 @@ public:
   // The client has protected access to the action handlers.
   friend class P2PActionClient;
 
+  // Does not take ownership of the pointees, which must outlive this object.
   P2PActionClientHandlerBase(P2PAction action, P2PPriority default_priority, bool default_guarantee_delivery, P2PPacketStreamLinux *p2p_stream, std::mutex *p2p_mutex, bool allows_concurrent_requests = false)
     : action_(action), 
       priority_(default_priority),
@@ -48,10 +49,19 @@ public:
   virtual void OnReply(int payload_length, const void *payload);
   virtual void OnProgress(int payload_length, const void *payload);
   virtual void OnOtherEndStarted();
+  // Called when the action could not be completed.
+  // For instance, because the other end was restarted.
+  virtual void OnAbort();
 
 protected:
+  using State = enum { kIdle, kWaitingForResponse, kCancelling };
+
   // Must be called with p2p_mutex_ locked.
   P2PActionRequestID current_request_id() const { return current_request_id_; }
+  State state() const { return state_; }
+  // Manages the lifecycle of the action. 
+  // Must be called from the action client after locking p2p_mutex_.
+  void Run();
 
 private:
   P2PAction action_;
@@ -62,8 +72,8 @@ private:
   std::mutex &p2p_mutex_;
   const bool allows_concurrent_requests_;
 
-  using State = enum { kIdle, kWaitingForResponse };
-  // Since the state is atomic, we can read it without locking.
+  // Since the state is atomic, we can read it without locking for single-read decisions, like in_progress().
+  // For writing or multiple-read decisions, lock p2p_mutex_ first.
   std::atomic<State> state_;
 };
 
@@ -75,15 +85,15 @@ public:
 
   using OnReplyCallback = std::function<void(const TRequest &, const TReply &)>;
   using OnProgressCallback = std::function<void(const TRequest &, const TProgress &)>;
-  using OnOtherEndStartedCallback = std::function<void(const TRequest &)>;
+  using OnAbortCallback = std::function<void(const TRequest &)>;
 
   // Takes ownsership of the callbacks.
   // See the base class' function for more details.
-  Status Request(const TRequest &request, OnReplyCallback &&reply_callback, OnProgressCallback &&progress_callback, OnOtherEndStartedCallback &&other_end_started_callback = [](const TRequest &r){}, std::optional<P2PPriority> priority = std::nullopt, std::optional<bool> guarantee_delivery = std::nullopt) {
+  Status Request(const TRequest &request, OnReplyCallback &&reply_callback, OnProgressCallback &&progress_callback, OnAbortCallback &&abort_callback = [](const TRequest &){}, std::optional<P2PPriority> priority = std::nullopt, std::optional<bool> guarantee_delivery = std::nullopt) {
     last_request_ = request;
     reply_callback_ = reply_callback;
     progress_callback_ = progress_callback;
-    other_end_started_callback_ = other_end_started_callback;
+    abort_callback_ = abort_callback;
     return P2PActionClientHandlerBase::Request(sizeof(TRequest), &request, priority, guarantee_delivery);
   }
 
@@ -98,22 +108,22 @@ protected:
     P2PActionClientHandlerBase::OnProgress(payload_length, payload);
     progress_callback_(last_request_, *reinterpret_cast<const TProgress *>(payload));
   }
-  virtual void OnOtherEndStarted() override {
-    P2PActionClientHandlerBase::OnOtherEndStarted();
-    other_end_started_callback_(last_request_);
+  virtual void OnAbort() override {
+    P2PActionClientHandlerBase::OnAbort();
+    abort_callback_(last_request_);
   }
 
 private:
   TRequest last_request_;   // Action requests cannot overlap.
   OnReplyCallback reply_callback_ = [](const TRequest &, const TReply &){};
   OnProgressCallback progress_callback_ = [](const TRequest &, const TProgress &){};
-  OnOtherEndStartedCallback other_end_started_callback_ = [](const TRequest &){};
+  OnAbortCallback abort_callback_ = [](const TRequest &){};
 };
 
 class P2PActionClient {
 public:
   // Does not take ownership of the pointees, which must outlive this object.
-  P2PActionClient(P2PPacketStreamLinux *p2p_stream, const TimerInterface *system_timer);
+  P2PActionClient(P2PPacketStreamLinux *p2p_stream, const TimerInterface *system_timer, std::mutex *p2p_mutex);
 
   // Does not take ownsership of the pointee, which must outlive this object.
   void Register(P2PActionClientHandlerBase *handler);
@@ -135,6 +145,7 @@ private:
 
   P2PPacketStreamLinux &p2p_stream_;
   const TimerInterface &system_timer_;
+  std::mutex &p2p_mutex_;
   P2PActionClientHandlerBase *handlers_[P2PAction::kCount];
 };
 

--- a/hf1/linux/p2p_action_client.h
+++ b/hf1/linux/p2p_action_client.h
@@ -45,12 +45,21 @@ public:
   // True if the action is being executed; false, otherwise.
   bool in_progress() const;
 
-  // Overrides must call the parent.
+  // Called when a reply is received.
+  // Overrides must call the parent. Called with p2p_mutex locked.
   virtual void OnReply(int payload_length, const void *payload);
+
+  // Called when a progress packet is received.
+  // Overrides must call the parent. Called with p2p_mutex locked.
   virtual void OnProgress(int payload_length, const void *payload);
+
+  // Called right after the other end starts.
+  // Overrides must call the parent. Called with p2p_mutex locked.
   virtual void OnOtherEndStarted();
+
   // Called when the action could not be completed.
   // For instance, because the other end was restarted.
+  // Overrides must call the parent. Called with p2p_mutex locked.
   virtual void OnAbort();
 
 protected:
@@ -123,7 +132,7 @@ private:
 class P2PActionClient {
 public:
   // Does not take ownership of the pointees, which must outlive this object.
-  P2PActionClient(P2PPacketStreamLinux *p2p_stream, const TimerInterface *system_timer, std::mutex *p2p_mutex);
+  P2PActionClient(P2PPacketStreamLinux *p2p_stream, const TimerInterface *system_timer);
 
   // Does not take ownsership of the pointee, which must outlive this object.
   void Register(P2PActionClientHandlerBase *handler);
@@ -145,7 +154,6 @@ private:
 
   P2PPacketStreamLinux &p2p_stream_;
   const TimerInterface &system_timer_;
-  std::mutex &p2p_mutex_;
   P2PActionClientHandlerBase *handlers_[P2PAction::kCount];
 };
 


### PR DESCRIPTION
After the motion controller has been restarted, no actions are executing. This new state must be reflected in the action client as well. Thus, any running ros2 actions must be aborted and, in case guaranteed-delivery request packets were received by the other end right after restarting, cancellation packets must be scheduled for any running action. This PR does the latter in the action client of the Linux side and creates a new OnAbort() callback for the p2p-ros2 gateway to abort the corresponding ros2 actions.