### PR TITLE
Request() returns kOverflowError if encoded packet does not fit p2p slot.

### DIFF
--- a/hf1/common/status_or.h
+++ b/hf1/common/status_or.h
@@ -4,7 +4,7 @@
 #include "logger_interface.h"
 
 enum Status {
-  kSuccess, kUnavailableError, kMalformedError, kExistsError, kDoesNotExistError, kInProgressError, kInUseError
+  kSuccess, kUnavailableError, kMalformedError, kExistsError, kDoesNotExistError, kInProgressError, kInUseError, kOverflowError
 };
 
 template<typename ValueType> class StatusOr {

--- a/hf1/linux/p2p_action_client.cpp
+++ b/hf1/linux/p2p_action_client.cpp
@@ -23,7 +23,9 @@ Status P2PActionClientHandlerBase::Request(int payload_length, const void *paylo
   header->stage = P2PActionStage::kRequest;
   header->request_id = ++current_request_id_;
   memcpy(maybe_new_packet->content() + sizeof(P2PApplicationPacketHeader), payload, payload_length);
-  p2p_stream_.output().Commit(maybe_new_packet->priority(), guarantee_delivery.has_value() ? *guarantee_delivery : guarantee_delivery_);
+  if (!p2p_stream_.output().Commit(maybe_new_packet->priority(), guarantee_delivery.has_value() ? *guarantee_delivery : guarantee_delivery_)) {
+    return Status::kOverflowError;
+  }
 
   state_ = allows_concurrent_requests_ ? kIdle : kWaitingForResponse;
   return Status::kSuccess;
@@ -54,7 +56,8 @@ Status P2PActionClientHandlerBase::Cancel(std::optional<P2PPriority> priority, s
   header->action = action_;
   header->stage = P2PActionStage::kCancel;
   header->request_id = current_request_id_;
-  p2p_stream_.output().Commit(maybe_new_packet->priority(), guarantee_delivery.has_value() ? *guarantee_delivery : guarantee_delivery_);
+  // A cancellation packet should never overflow.
+  ASSERT(p2p_stream_.output().Commit(maybe_new_packet->priority(), guarantee_delivery.has_value() ? *guarantee_delivery : guarantee_delivery_));
 
   state_ = kIdle;
   return Status::kSuccess;

--- a/hf1/linux/p2p_action_client.h
+++ b/hf1/linux/p2p_action_client.h
@@ -28,17 +28,21 @@ public:
   // Sends an action request message with the given `payload`.
   // If `priority` and `guarantee_delivery` are passed, they override the default
   // configuration passed in the constructor.
-  // If successful, it resturn Status::kSuccess.
-  // If the action is already in progress, it returns Status::kExistsError.
-  // If no P2P packet slots are available to send the message, it returns Status::kUnavailableError.
+  // It can return the following error codes:
+  //  Status::kSuccess - the request was placed in the P2P output queue.
+  //  Status::kUnavailableError - no P2P packet slots are available to send the message.
+  //  Status::kExistsError - the action was already in progress.
+  //  Status::kOverflowError - the P2P-encoded request packet does not fit in a slot of the output queue. 
+  //    Encoded packets may be longer due to double-byte encoding of special characters.
   Status Request(int payload_length, const void *payload, std::optional<P2PPriority> priority = std::nullopt, std::optional<bool> guarantee_delivery = std::nullopt);
 
   // Sends an action cancellation message.
   // If `priority` and `guarantee_delivery` are passed, they override the default
   // configuration passed in the constructor.
-  // If successful, it resturn Status::kSuccess.
-  // If the action was not in progress, it returns Status::kDoesNotExistsError.
-  // If no P2P packet slots are available to send the message, it returns Status::kUnavailableError.
+  // It can return the following error codes:
+  //  Status::kSuccess - the cancellation packet was placed in the P2P output queue.
+  //  Status::kUnavailableError - no P2P packet slots are available to send the message.
+  //  Status::kExistsError - the action was not in progress.
   Status Cancel(std::optional<P2PPriority> priority = std::nullopt, std::optional<bool> guarantee_delivery = std::nullopt);
 
   P2PAction action() const { return action_; }


### PR DESCRIPTION
Fixes #27.