### PR TITLE
P2P action abort packets are passed back to ROS2 action clients.

### DIFF
--- a/hf1/arduino/p2p_action_server.h
+++ b/hf1/arduino/p2p_action_server.h
@@ -102,11 +102,14 @@ public:
   // but it should not be cached across callbacks as it might change over time.
   const TRequest &GetRequest() const;
 
-  // Creates a TReply in a new output stream packet or returns an error status.
+  // Allocates an output stream packet and creates a reply, or returns an error status.
   StatusOr<P2PActionPacketAdapter<TReply>> NewReply();
 
-  // Creates a TProgress in a new output packet or returns an error status.
+  // Allocates an output stream packet and creates a progress update, or returns an error status.
   StatusOr<P2PActionPacketAdapter<TProgress>> NewProgress();
+
+  // Allocates an output stream packet and creates an abort notification, or returns an error status.
+  StatusOr<P2PActionPacketAdapter<TReply>> NewAbort();
 
   int GetExpectedRequestSize() const override {
     return sizeof(TRequest);

--- a/hf1/arduino/p2p_action_server.hh
+++ b/hf1/arduino/p2p_action_server.hh
@@ -40,3 +40,17 @@ StatusOr<P2PActionPacketAdapter<TProgress>> P2PActionHandler<TRequest, TReply, T
   header->request_id = request_id();
   return P2PActionPacketAdapter<TProgress>(this, *maybe_packet);
 }
+
+template<typename TRequest, typename TReply, typename TProgress>
+StatusOr<P2PActionPacketAdapter<TReply>> P2PActionHandler<TRequest, TReply, TProgress>::NewAbort() {
+  StatusOr<P2PMutablePacketView> maybe_packet = p2p_stream().output().NewPacket(request_priority());
+  if (!maybe_packet.ok()) {
+    return maybe_packet.status();
+  }
+  maybe_packet->length() = sizeof(P2PApplicationPacketHeader) + sizeof(TReply);
+  P2PApplicationPacketHeader *header = reinterpret_cast<P2PApplicationPacketHeader *>(maybe_packet->content());
+  header->action = action();
+  header->stage = P2PActionStage::kCancel;
+  header->request_id = request_id();
+  return P2PActionPacketAdapter<TReply>(this, *maybe_packet);
+}

--- a/hf1/linux/p2p_action_client.cpp
+++ b/hf1/linux/p2p_action_client.cpp
@@ -182,7 +182,10 @@ void P2PActionClient::Run() {
       handler->OnReply(maybe_packet->length() - sizeof(P2PApplicationPacketHeader), payload);
       break;
     case P2PActionStage::kProgress:
-      handler->OnProgress(maybe_packet->length() - sizeof(P2PApplicationPacketHeader), payload);
+      handler->OnProgress(maybe_packet->length() - sizeof(P2PApplicationPacketHeader), payload);      
+      break;
+    case P2PActionStage::kCancel:
+      handler->OnAbort(maybe_packet->length() - sizeof(P2PApplicationPacketHeader), payload);
       break;
     default: {
       std::ostringstream oss;


### PR DESCRIPTION
Fixes #31.