### PR TITLE
Stop and prevent motion when connection with client lost.

### DIFF
--- a/hf1/arduino/arduino.ino
+++ b/hf1/arduino/arduino.ino
@@ -90,7 +90,6 @@ P2PPacketStreamArduino p2p_stream(&byte_stream, &timer, guid_factory);
 
 BaseIMU base_imu(kPersistanceOffsetBaseIMUCalibration);
 
-P2PActionClientStatus p2p_action_client_status("P2PActionClientStatus");
 WheelStateEstimator wheel_state_estimator("WheelStateEstimator");
 WheelSpeedController left_wheel("LeftWheelSpeedController", &wheel_state_estimator.left_wheel_state_filter(), &SetLeftMotorDutyCycle);
 WheelSpeedController right_wheel("RightWheelSpeedController", &wheel_state_estimator.right_wheel_state_filter(), &SetRightMotorDutyCycle);
@@ -101,10 +100,6 @@ HeadTrajectoryController head_trajectory_controller("HeadTrajectoryController");
 TrajectoryStore trajectory_store;
 
 P2PActionServer p2p_action_server(&p2p_stream);
-static void ping_received_callback() {
-  p2p_action_client_status.NotifyPingReceived();
-}
-PingActionHandler ping_action_handler(&p2p_stream, ping_received_callback);
 SetHeadPoseActionHandler set_head_pose_action_handler(&p2p_stream);
 SetBaseVelocityActionHandler set_base_velocity_action_handler(&p2p_stream, &base_speed_controller);
 SyncTimeActionHandler sync_time_action_handler(&p2p_stream, &timer);
@@ -121,6 +116,36 @@ CreateBaseMixedTrajectoryViewActionHandler create_base_mixed_trajectory_view_act
 CreateHeadMixedTrajectoryViewActionHandler create_head_mixed_trajectory_view_action_handler(&p2p_stream, &trajectory_store);
 ExecuteBaseTrajectoryViewActionHandler execute_base_trajectory_view_action_handler(&p2p_stream, &trajectory_store, &base_trajectory_controller);
 ExecuteHeadTrajectoryViewActionHandler execute_head_trajectory_view_action_handler(&p2p_stream, &trajectory_store, &head_trajectory_controller);
+
+static void link_status_changed_callback(P2PActionClientStatus::LinkStatus old_status, P2PActionClientStatus::LinkStatus new_status) {
+  switch(new_status) {
+    case P2PActionClientStatus::LinkStatus::kInactive: {
+      // The action client is inactive (stopped pinging). 
+      // For safety, stop all motion, abort all trajectories beig executed, 
+      // and disable the actions to prevent any pending requests in the input queue from being processed.
+      // The guaranteed-delivery abort messages will make it to the action client as soon as it comes back.
+      base_trajectory_controller.Stop();
+      head_trajectory_controller.Stop();
+      execute_base_trajectory_view_action_handler.Abort();
+      execute_head_trajectory_view_action_handler.Abort();
+      execute_base_trajectory_view_action_handler.is_enabled(false);
+      execute_head_trajectory_view_action_handler.is_enabled(false);
+      break;
+    }
+    case P2PActionClientStatus::LinkStatus::kActive: {
+      // Re-enable the motion execution actions.
+      execute_base_trajectory_view_action_handler.is_enabled(true);
+      execute_head_trajectory_view_action_handler.is_enabled(true);
+      break;
+    }
+  }
+}
+P2PActionClientStatus p2p_action_client_status("P2PActionClientStatus", &link_status_changed_callback);
+
+static void ping_received_callback() {
+  p2p_action_client_status.NotifyPingReceived();
+}
+PingActionHandler ping_action_handler(&p2p_stream, ping_received_callback);
 
 Console console(&Serial);
 

--- a/hf1/arduino/execute_base_trajectory_view_action_handler.cpp
+++ b/hf1/arduino/execute_base_trajectory_view_action_handler.cpp
@@ -23,9 +23,15 @@ bool ExecuteBaseTrajectoryViewActionHandler::Run() {
       const auto trajectory_view_type = static_cast<P2PTrajectoryViewType>(NetworkToLocal<kP2PLocalEndianness>(request.trajectory_view_id.type));
       last_progress_update_ns_ = 0;
 
-      char str[100];
-      sprintf(str, "execute_base_trajectory_view(trajectory_view_type=%d, trajectory_view_id=%d)", trajectory_view_type, trajectory_view_id);
-      LOG_INFO(str);
+      if (is_enabled_) {
+        char str[100];
+        sprintf(str, "execute_base_trajectory_view(trajectory_view_type=%d, trajectory_view_id=%d)", trajectory_view_type, trajectory_view_id);
+        LOG_INFO(str);
+      } else {
+        LOG_WARNING("execute_base_trajectory_view() rejected because it's disabled.");
+        state_ = kSendingAbort;
+        break;
+      }
 
       TrajectoryViewInterface<BaseTargetState> *trajectory_view = nullptr;
       switch(trajectory_view_type) {
@@ -111,8 +117,23 @@ bool ExecuteBaseTrajectoryViewActionHandler::Run() {
       }
       break;
     }
+
+    case kSendingAbort: {
+      if (TrySendingAbort()) {
+        state_ = kProcessingRequest;
+        return false; // Do not loop anymore.
+      }
+    }
   }
   return true;  // Keep looping.
+}
+
+void ExecuteBaseTrajectoryViewActionHandler::Abort() {
+  if (run_state() != kRunning) {
+    return;
+  }
+  base_trajectory_controller_.Stop();
+  state_ = kSendingAbort;
 }
 
 bool ExecuteBaseTrajectoryViewActionHandler::TrySendingReply() {
@@ -136,6 +157,18 @@ bool ExecuteBaseTrajectoryViewActionHandler::TrySendingProgress() {
   P2PActionPacketAdapter<P2PExecuteBaseTrajectoryViewProgress> progress = *maybe_progress;
   progress->num_completed_laps = LocalToNetwork<kP2PLocalEndianness>(base_trajectory_controller_.NumCompletedLaps());
   progress.Commit(/*guarantee_delivery=*/false);
+  return true;
+}
+
+bool ExecuteBaseTrajectoryViewActionHandler::TrySendingAbort() {
+  StatusOr<P2PActionPacketAdapter<P2PExecuteBaseTrajectoryViewReply>> maybe_reply = NewAbort();
+  if (!maybe_reply.ok()) {
+    return false;
+  }
+  last_progress_update_ns_ = GetTimerNanoseconds();
+  P2PActionPacketAdapter<P2PExecuteBaseTrajectoryViewReply> reply = *maybe_reply;
+  reply->status_code = LocalToNetwork<kP2PLocalEndianness>(Status::kAbortedError);
+  reply.Commit(/*guarantee_delivery=*/true);
   return true;
 }
 

--- a/hf1/arduino/execute_base_trajectory_view_action_handler.h
+++ b/hf1/arduino/execute_base_trajectory_view_action_handler.h
@@ -12,21 +12,31 @@ public:
   ExecuteBaseTrajectoryViewActionHandler(P2PPacketStreamArduino *p2p_stream, TrajectoryStore *trajectory_store, BaseTrajectoryController *base_trajectory_controller)
     : P2PActionHandler<P2PExecuteBaseTrajectoryViewRequest, P2PExecuteBaseTrajectoryViewReply, P2PExecuteBaseTrajectoryViewProgress>(P2PAction::kExecuteBaseTrajectoryView, p2p_stream), 
       trajectory_store_(*ASSERT_NOT_NULL(trajectory_store)),
-      base_trajectory_controller_(*ASSERT_NOT_NULL(base_trajectory_controller)) {}
+      base_trajectory_controller_(*ASSERT_NOT_NULL(base_trajectory_controller)), 
+      is_enabled_(true) {}
 
   bool Run() override;
+  void Abort() override;
+
   bool OnRequest() override;
   void OnCancel() override;
+
+  // If `ie` is true, the action handler processes requests.
+  // Otherwise, requests are rejected with an abort packet.
+  void is_enabled(bool ie) { is_enabled_ = ie; }
+  bool is_enabled() const { return is_enabled_; }
 
 private:
   bool TrySendingReply();
   bool TrySendingProgress();
+  bool TrySendingAbort();
 
   TrajectoryStore &trajectory_store_;  
   BaseTrajectoryController &base_trajectory_controller_;
+  bool is_enabled_;
   Status result_;
   uint64_t last_progress_update_ns_;
-  enum { kProcessingRequest, kSendingReply, kWaitForNextProgressUpdate, kSendingProgress } state_ = kProcessingRequest;
+  enum { kProcessingRequest, kSendingReply, kWaitForNextProgressUpdate, kSendingProgress, kSendingAbort } state_ = kProcessingRequest;
 };
 
 #endif  // EXECUTE_BASE_TRAJECTORY_VIEW_ACTION_HANDLER_

--- a/hf1/arduino/execute_head_trajectory_view_action_handler.cpp
+++ b/hf1/arduino/execute_head_trajectory_view_action_handler.cpp
@@ -23,9 +23,16 @@ bool ExecuteHeadTrajectoryViewActionHandler::Run() {
       const auto trajectory_view_type = static_cast<P2PTrajectoryViewType>(NetworkToLocal<kP2PLocalEndianness>(request.trajectory_view_id.type));
       last_progress_update_ns_ = 0;
 
-      char str[100];
-      sprintf(str, "execute_head_trajectory_view(trajectory_view_type=%d, trajectory_view_id=%d)", trajectory_view_type, trajectory_view_id);
-      LOG_INFO(str);
+      if (is_enabled_) {
+        char str[100];
+        sprintf(str, "execute_head_trajectory_view(trajectory_view_type=%d, trajectory_view_id=%d)", trajectory_view_type, trajectory_view_id);
+        LOG_INFO(str);
+      } else {
+        // The action is disabled: do not run it and send back an abort notification.
+        LOG_WARNING("execute_head_trajectory_view() rejected because it's disabled.");
+        state_ = kSendingAbort;
+        break;
+      }
 
       TrajectoryViewInterface<HeadTargetState> *trajectory_view = nullptr;
       switch(trajectory_view_type) {
@@ -111,8 +118,23 @@ bool ExecuteHeadTrajectoryViewActionHandler::Run() {
       }
       break;
     }
+
+    case kSendingAbort: {
+      if (TrySendingAbort()) {
+        state_ = kProcessingRequest;
+        return false; // Do not loop anymore.
+      }
+    }
   }
   return true;  // Keep looping.
+}
+
+void ExecuteHeadTrajectoryViewActionHandler::Abort() {
+  if (run_state() != kRunning) {
+    return;
+  }
+  head_trajectory_controller_.Stop();
+  state_ = kSendingAbort;
 }
 
 bool ExecuteHeadTrajectoryViewActionHandler::TrySendingReply() {
@@ -136,6 +158,18 @@ bool ExecuteHeadTrajectoryViewActionHandler::TrySendingProgress() {
   P2PActionPacketAdapter<P2PExecuteHeadTrajectoryViewProgress> progress = *maybe_progress;
   progress->num_completed_laps = LocalToNetwork<kP2PLocalEndianness>(head_trajectory_controller_.NumCompletedLaps());
   progress.Commit(/*guarantee_delivery=*/false);
+  return true;
+}
+
+bool ExecuteHeadTrajectoryViewActionHandler::TrySendingAbort() {
+  StatusOr<P2PActionPacketAdapter<P2PExecuteHeadTrajectoryViewReply>> maybe_reply = NewAbort();
+  if (!maybe_reply.ok()) {
+    return false;
+  }
+  last_progress_update_ns_ = GetTimerNanoseconds();
+  P2PActionPacketAdapter<P2PExecuteHeadTrajectoryViewReply> reply = *maybe_reply;
+  reply->status_code = LocalToNetwork<kP2PLocalEndianness>(Status::kAbortedError);
+  reply.Commit(/*guarantee_delivery=*/true);
   return true;
 }
 

--- a/hf1/arduino/execute_head_trajectory_view_action_handler.h
+++ b/hf1/arduino/execute_head_trajectory_view_action_handler.h
@@ -12,21 +12,31 @@ public:
   ExecuteHeadTrajectoryViewActionHandler(P2PPacketStreamArduino *p2p_stream, TrajectoryStore *trajectory_store, HeadTrajectoryController *head_trajectory_controller)
     : P2PActionHandler<P2PExecuteHeadTrajectoryViewRequest, P2PExecuteHeadTrajectoryViewReply, P2PExecuteHeadTrajectoryViewProgress>(P2PAction::kExecuteHeadTrajectoryView, p2p_stream), 
       trajectory_store_(*ASSERT_NOT_NULL(trajectory_store)),
-      head_trajectory_controller_(*ASSERT_NOT_NULL(head_trajectory_controller)) {}
+      head_trajectory_controller_(*ASSERT_NOT_NULL(head_trajectory_controller)),
+      is_enabled_(true) {}
 
   bool Run() override;
+  void Abort() override;
+
   bool OnRequest() override;
   void OnCancel() override;
+
+  // If `ie` is true, the action handler processes requests.
+  // Otherwise, requests are rejected with an abort packet.
+  void is_enabled(bool ie) { is_enabled_ = ie; }
+  bool is_enabled() const { return is_enabled_; }
 
 private:
   bool TrySendingReply();
   bool TrySendingProgress();
+  bool TrySendingAbort();
 
   TrajectoryStore &trajectory_store_;  
   HeadTrajectoryController &head_trajectory_controller_;
+  bool is_enabled_;
   Status result_;
   uint64_t last_progress_update_ns_;
-  enum { kProcessingRequest, kSendingReply, kWaitForNextProgressUpdate, kSendingProgress } state_ = kProcessingRequest;
+  enum { kProcessingRequest, kSendingReply, kWaitForNextProgressUpdate, kSendingProgress, kSendingAbort } state_ = kProcessingRequest;
 };
 
 #endif  // EXECUTE_HEAD_TRAJECTORY_VIEW_ACTION_HANDLER_

--- a/hf1/arduino/p2p_action_client_status.cpp
+++ b/hf1/arduino/p2p_action_client_status.cpp
@@ -6,8 +6,8 @@ constexpr TimerNanosType kMinPingDelayForInactiveNs = 1'300'000'000ULL;
 
 static_assert(kMinPingDelayForInactiveNs > kRunPeriodNs);
 
-P2PActionClientStatus::P2PActionClientStatus(const char *name)
-  : PeriodicRunnable(name, kRunPeriodNs), link_status_(kInactive), last_ping_notification_ns_(-1ULL) {}
+P2PActionClientStatus::P2PActionClientStatus(const char *name, LinkStatusChangedCallback link_status_changed_callback)
+  : PeriodicRunnable(name, kRunPeriodNs), link_status_(kInactive), last_ping_notification_ns_(-1ULL), link_status_changed_callback_(link_status_changed_callback) {}
 
 void P2PActionClientStatus::NotifyPingReceived() {
   last_ping_notification_ns_ = GetTimerNanoseconds();

--- a/hf1/arduino/p2p_action_client_status.h
+++ b/hf1/arduino/p2p_action_client_status.h
@@ -9,8 +9,13 @@
 class P2PActionClientStatus : public PeriodicRunnable {
 public:
   enum LinkStatus { kInactive, kActive };
+  using LinkStatusChangedCallback = void (*)(LinkStatus old_status, LinkStatus new_status);
 
-  P2PActionClientStatus(const char *name);
+  // Creates the object with a `name`.
+  // `link_status_changed_callback`, if not nulptr, is called every time the link status changes.
+  // Copies `name` to an internal buffer, so it can be discarded constructing the object.
+  // Does not take ownership of `link_status_changed_callback`, which must outlive this object.
+  P2PActionClientStatus(const char *name, LinkStatusChangedCallback link_status_changed_callback);
 
   // Must be called whenever a ping action is received.
   void NotifyPingReceived();
@@ -23,6 +28,7 @@ protected:
 private:
   LinkStatus link_status_; 
   TimerNanosType last_ping_notification_ns_;
+  LinkStatusChangedCallback link_status_changed_callback_;
 };
 
 #endif  // P2P_ACTION_CLIENT_STATUS_

--- a/hf1/arduino/p2p_action_server.h
+++ b/hf1/arduino/p2p_action_server.h
@@ -36,7 +36,7 @@ public:
   bool is_registered() const { return is_registered_; }
   void is_registered(bool ir) { is_registered_ = ir; }
   bool is_initialized() const { return is_initialized_; }
-  void is_initialized(bool ii) { is_initialized_ = ii; }  
+  void is_initialized(bool ii) { is_initialized_ = ii; }
   P2PAction action() const { return action_; }
   RunState run_state() const { return run_state_; }
   void run_state(RunState state) { run_state_ = state; }
@@ -57,6 +57,10 @@ public:
 
   // Called once from the server's Run() before any other callbacks.
   virtual void Init() {}
+
+  // Aborts the action from the server side of the P2P link.
+  // Subclasses must override this function to stop the action and send back a abort notification.
+  virtual void Abort() {}
 
   // Called when the action request is received. Returns whether the action will be started.
   // If false, the other end receives a P2PActionStage::kCancel stage; otherwise, the other 

--- a/hf1/common/status_or.h
+++ b/hf1/common/status_or.h
@@ -4,7 +4,7 @@
 #include "logger_interface.h"
 
 enum Status {
-  kSuccess, kUnavailableError, kMalformedError, kExistsError, kDoesNotExistError, kInProgressError, kInUseError, kOverflowError, kRestartedError
+  kSuccess, kUnavailableError, kMalformedError, kExistsError, kDoesNotExistError, kInProgressError, kInUseError, kOverflowError, kRestartedError, kAbortedError
 };
 
 template<typename ValueType> class StatusOr {


### PR DESCRIPTION
Fixes #24. 

Upon connection with client lost, stop all motion, abort running motion actions and disable future motion action requests.

Upon reconnection, reenable motion action requests.