### PR TITLE
Action requests are shrunk to actual payload before sending.

### DIFF
--- a/hf1/arduino/p2p_action_server.cpp
+++ b/hf1/arduino/p2p_action_server.cpp
@@ -75,12 +75,9 @@ StatusOr<const P2PPacketView> P2PActionServer::GetRequestOrCancellation() const 
     return Status::kMalformedError;
   }
 
-  // TODO: fix this.
-  // if (app_header->stage == P2PActionStage::kRequest) {
-  //   ASSERT(maybe_oldest_packet_view->length() == sizeof(P2PApplicationPacketHeader) + handler->GetExpectedRequestSize());
-  // } else {
-  //   ASSERT(maybe_oldest_packet_view->length() == sizeof(P2PApplicationPacketHeader));
-  // }
+  // Requests may be shorter than their max size because they hold fewer elements in array fields, so check size is under maximum.
+  // It is ok to static cast app_header->stage to the enum since we have checked that it's either kRequest or kCancellation.
+  ASSERT(maybe_oldest_packet_view->length() <= sizeof(P2PApplicationPacketHeader) + handler->GetMaximumContentSize(static_cast<P2PActionStage>(app_header->stage)));
 
   return maybe_oldest_packet_view;
 }
@@ -118,7 +115,7 @@ void P2PActionServer::Run() {
         if (handler->Run()) {
           // The action goes on. Further calls to run will operate on a copy, as the input 
           // packet must be consumed for other packets to be processed.
-          memcpy(handler->GetRequestCopyBuffer(), maybe_packet->content() + sizeof(P2PApplicationPacketHeader), handler->GetExpectedRequestSize());
+          memcpy(handler->GetRequestCopyBuffer(), maybe_packet->content() + sizeof(P2PApplicationPacketHeader), handler->GetMaximumContentSize(P2PActionStage::kRequest));
           handler->request_bytes(handler->GetRequestCopyBuffer());    
           handler->run_state(P2PActionHandlerBase::RunState::kRunning);
         }

--- a/hf1/arduino/p2p_action_server.cpp
+++ b/hf1/arduino/p2p_action_server.cpp
@@ -75,11 +75,12 @@ StatusOr<const P2PPacketView> P2PActionServer::GetRequestOrCancellation() const 
     return Status::kMalformedError;
   }
 
-  if (app_header->stage == P2PActionStage::kRequest) {
-    ASSERT(maybe_oldest_packet_view->length() == sizeof(P2PApplicationPacketHeader) + handler->GetExpectedRequestSize());
-  } else {
-    ASSERT(maybe_oldest_packet_view->length() == sizeof(P2PApplicationPacketHeader));
-  }
+  // TODO: fix this.
+  // if (app_header->stage == P2PActionStage::kRequest) {
+  //   ASSERT(maybe_oldest_packet_view->length() == sizeof(P2PApplicationPacketHeader) + handler->GetExpectedRequestSize());
+  // } else {
+  //   ASSERT(maybe_oldest_packet_view->length() == sizeof(P2PApplicationPacketHeader));
+  // }
 
   return maybe_oldest_packet_view;
 }

--- a/hf1/arduino/p2p_action_server.h
+++ b/hf1/arduino/p2p_action_server.h
@@ -52,8 +52,11 @@ public:
   // Returns a pointer to a buffer where to copy the request when the action takes longer than a call to Run().
   virtual uint8_t *GetRequestCopyBuffer() = 0;
 
-  // Returns the expected request size.
-  virtual int GetExpectedRequestSize() const = 0;
+  // Returns the maximum content (packet minus application header) size that can be 
+  // received for a given action stage.
+  // Packets may be shorter than their corresponding structures if they have fewer
+  // elements in arrays, e.g. waypoints.
+  virtual int GetMaximumContentSize(P2PActionStage action_stage) const = 0;
 
   // Called once from the server's Run() before any other callbacks.
   virtual void Init() {}
@@ -115,10 +118,8 @@ public:
   // Allocates an output stream packet and creates an abort notification, or returns an error status.
   StatusOr<P2PActionPacketAdapter<TReply>> NewAbort();
 
-  int GetExpectedRequestSize() const override {
-    return sizeof(TRequest);
-  }
-
+  int GetMaximumContentSize(P2PActionStage action_stage) const override;
+  
   uint8_t *GetRequestCopyBuffer() override {
     return reinterpret_cast<uint8_t *>(&request_);
   }

--- a/hf1/arduino/p2p_action_server.hh
+++ b/hf1/arduino/p2p_action_server.hh
@@ -1,3 +1,15 @@
+template<typename TRequest, typename TReply, typename TProgress>
+int P2PActionHandler<TRequest, TReply, TProgress>::GetMaximumContentSize(P2PActionStage action_stage) const {
+  switch(action_stage) {
+    case P2PActionStage::kRequest: return sizeof(TRequest);
+    case P2PActionStage::kReply: return sizeof(TReply);
+    case P2PActionStage::kProgress: return sizeof(TProgress);
+    case P2PActionStage::kCancel: return 0;    
+    // The compiler should complain if not all cases are treated.
+  }
+  return 0;
+}
+
 template<typename TPacket>
 void P2PActionPacketAdapter<TPacket>::Commit(bool guarantee_delivery) {
   action_handler_->p2p_stream().output().Commit(packet_view_.priority(), guarantee_delivery);

--- a/hf1/common/p2p_application_protocol.h
+++ b/hf1/common/p2p_application_protocol.h
@@ -71,15 +71,24 @@ typedef struct {
 
 // --- Void action ---
 typedef struct {
-  uint8_t reserved;
+  // Some compilers do sizeof(empty_struct)==1 to comply with the "different objects have different pointers" standard.
+  // Some can be configured to do sizeof(empty_struct)==0. Better to inflate the struct explicitly and have the same 
+  // size across binaries that may be built with different compilers.
+  uint8_t reserved; 
 } P2PVoid;
 
 // --- Ping ---
 typedef struct  {
+  // Some compilers do sizeof(empty_struct)==1 to comply with the "different objects have different pointers" standard.
+  // Some can be configured to do sizeof(empty_struct)==0. Better to inflate the struct explicitly and have the same 
+  // size across binaries that may be built with different compilers.
   uint8_t reserved;
 } P2PPingRequest;
 
 typedef struct {
+  // Some compilers do sizeof(empty_struct)==1 to comply with the "different objects have different pointers" standard.
+  // Some can be configured to do sizeof(empty_struct)==0. Better to inflate the struct explicitly and have the same 
+  // size across binaries that may be built with different compilers.
   uint8_t reserved;
 } P2PPingReply;
 

--- a/hf1/common/p2p_application_protocol.h
+++ b/hf1/common/p2p_application_protocol.h
@@ -70,13 +70,17 @@ typedef struct {
 } P2PApplicationPacketHeader;
 
 // --- Void action ---
-typedef struct {} P2PVoid;
+typedef struct {
+  uint8_t reserved;
+} P2PVoid;
 
 // --- Ping ---
 typedef struct  {
+  uint8_t reserved;
 } P2PPingRequest;
 
 typedef struct {
+  uint8_t reserved;
 } P2PPingReply;
 
 // --- Time synchronization ---

--- a/hf1/linux/p2p_action_client.h
+++ b/hf1/linux/p2p_action_client.h
@@ -91,7 +91,20 @@ private:
   std::atomic<State> state_;
 };
 
-template<typename TRequest, typename TReply = P2PVoid, typename TProgress = P2PVoid> class P2PActionClientHandler : public P2PActionClientHandlerBase {
+template<typename TRequest> struct LiteralRequestSizeCalculator {
+  static int CalculateRequestSize(const TRequest &r) { 
+    return sizeof(TRequest); 
+  }
+};
+
+template<typename TRequest> struct CreateTrajectoryRequestSizeCalculator {
+  static int CalculateRequestSize(const TRequest &request) { 
+    return sizeof(request) - sizeof(request.trajectory.waypoints) + request.trajectory.num_waypoints * sizeof(request.trajectory.waypoints[0]);
+  }
+};
+
+template<typename TRequest, typename TReply = P2PVoid, typename TProgress = P2PVoid, typename TRequestSizeCalculator = LiteralRequestSizeCalculator<TRequest>> 
+class P2PActionClientHandler : public P2PActionClientHandlerBase {
 public:
   // Does not take ownership of the pointees, which must outlive this object.
   P2PActionClientHandler(P2PAction action, P2PPriority default_priority, bool default_guarantee_delivery, P2PPacketStreamLinux *p2p_stream, std::mutex *p2p_mutex, bool allows_concurrent_requests = false)
@@ -103,12 +116,13 @@ public:
 
   // Takes ownsership of the callbacks.
   // See the base class' function for more details.
-  Status Request(const TRequest &request, OnReplyCallback &&reply_callback, OnProgressCallback &&progress_callback, OnAbortCallback &&abort_callback, std::optional<P2PPriority> priority = std::nullopt, std::optional<bool> guarantee_delivery = std::nullopt) {
+  Status Request(const TRequest &request, OnReplyCallback reply_callback, OnProgressCallback progress_callback, OnAbortCallback abort_callback, std::optional<P2PPriority> priority = std::nullopt, std::optional<bool> guarantee_delivery = std::nullopt) {
     last_request_ = request;
-    reply_callback_ = reply_callback;
-    progress_callback_ = progress_callback;
-    abort_callback_ = abort_callback;
-    return P2PActionClientHandlerBase::Request(sizeof(TRequest), &request, priority, guarantee_delivery);
+    reply_callback_ = std::move(reply_callback);
+    progress_callback_ = std::move(progress_callback);
+    abort_callback_ = std::move(abort_callback);
+    return P2PActionClientHandlerBase::Request(TRequestSizeCalculator::CalculateRequestSize(request), &request, priority, guarantee_delivery);
+    return Status::kSuccess;
   }
 
 protected:
@@ -136,9 +150,9 @@ protected:
 
 private:
   TRequest last_request_;   // Action requests cannot overlap.
-  OnReplyCallback reply_callback_ = [](const TRequest &, const TReply &){};
-  OnProgressCallback progress_callback_ = [](const TRequest &, const TProgress &){};
-  OnAbortCallback abort_callback_ = [](const TRequest &, const StatusOr<TReply> &){};
+  OnReplyCallback reply_callback_;
+  OnProgressCallback progress_callback_;
+  OnAbortCallback abort_callback_;
 };
 
 class P2PActionClient {


### PR DESCRIPTION
* Each templated action handler accepts a size calculator as template parameter.
* The calculator is called before every request to find out the actual size to send.
* The size of received requests and replies are checked against the maximum allowed size.

Paves the way to solve #27.